### PR TITLE
feat: initialize project structure and base modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,14 +146,14 @@ Each phase in the 6F architecture represents a focused stage of data handling:
 
 Everything is documented under the `/docs/` folder. Start with:
 
-- [`GETTING_STARTED.md`](docs/GETTING_STARTED.md)
-- [`HEXAGONAL_ARCHITECTURE_GUIDE.md`](docs/HEXAGONAL_ARCHITECTURE_GUIDE.md)
-- [`DEVELOPMENT_GUIDE.md`](docs/DEVELOPMENT_GUIDE.md)
-- [`USE_CASES.md`](docs/USE_CASES.md)
-- [`COMMIT_STRATEGY.md`](docs/COMMIT_STRATEGY.md)
-- [`PR_STRATEGY.md`](docs/PR_STRATEGY.md)
-- [`LABELLING_STRATEGY.md`](docs/LABELLING_STRATEGY.md)
-- [`ROADMAP.md`](docs/ROADMAP.md)
+- [GETTING_STARTED](docs/GETTING_STARTED.md)
+- [HEXAGONAL_ARCHITECTURE_GUIDE](docs/HEXAGONAL_ARCHITECTURE_GUIDE.md)
+- [DEVELOPMENT_GUIDE](docs/DEVELOPMENT_GUIDE.md)
+- [USE_CASES](docs/USE_CASES.md)
+- [COMMIT_STRATEGY](docs/COMMIT_STRATEGY.md)
+- [PR_STRATEGY](docs/PR_STRATEGY.md)
+- [LABELLING_STRATEGY](docs/LABELLING_STRATEGY.md)
+- [ROADMAP](docs/ROADMAP.md)
 
 Interactive web view at: [https://hexafn.com](https://hexafn.com)
 
@@ -211,7 +211,7 @@ pipeline.forward_to_store("user_sessions");
 pipeline.run().await?;
 ```
 
-Use `.env` or CLI args for environment config. See [`CONFIGURATION.md`](docs/CONFIGURATION.md).
+Use `.env` or CLI args for environment config. See [CONFIGURATION](docs/CONFIGURATION.md).
 
 ### Next Steps
 
@@ -235,11 +235,11 @@ This AI-driven approach ensures consistency across the codebase and demonstrates
 
 Please read:
 
-- [`SUMMARY.md`](docs/SUMMARY.md)
-- [`CONTRIBUTING.md`](docs/CONTRIBUTING.md)
-- [`TODO_LIST.md`](docs/TODO_LIST.md)
-- [`CODE_OF_CONDUCT.md`](docs/CODE_OF_CONDUCT.md)
-- [`AI_CONTRIBUTION_GUIDE.md`](docs/AI_CONTRIBUTION_GUIDE.md)
+- [SUMMARY](docs/SUMMARY.md)
+- [CONTRIBUTING](docs/CONTRIBUTING.md)
+- [TODO_LIST](docs/TODO_LIST.md)
+- [CODE_OF_CONDUCT](docs/CODE_OF_CONDUCT.md)
+- [AI_CONTRIBUTION_GUIDE](docs/AI_CONTRIBUTION_GUIDE.md)
 
 Good first issues: [help wanted](https://github.com/hTuneSys/hexaFn/labels/help%20wanted)
 

--- a/crates/hexafn-bridge/src/domain/contracts/integration.rs
+++ b/crates/hexafn-bridge/src/domain/contracts/integration.rs
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Husamettin ARABACI
+// SPDX-License-Identifier: MIT
+
+/// Trait for external integration contracts.
+pub trait Integration {
+    fn name(&self) -> &str;
+}

--- a/crates/hexafn-bridge/src/domain/contracts/mod.rs
+++ b/crates/hexafn-bridge/src/domain/contracts/mod.rs
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: 2025 Husamettin ARABACI
+// SPDX-License-Identifier: MIT
+
+pub mod integration;

--- a/crates/hexafn-cast/src/domain/contracts/mod.rs
+++ b/crates/hexafn-cast/src/domain/contracts/mod.rs
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: 2025 Husamettin ARABACI
+// SPDX-License-Identifier: MIT
+
+pub mod topic;

--- a/crates/hexafn-cast/src/domain/contracts/topic.rs
+++ b/crates/hexafn-cast/src/domain/contracts/topic.rs
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Husamettin ARABACI
+// SPDX-License-Identifier: MIT
+
+/// Trait for a pub/sub topic contract.
+pub trait Topic {
+    fn name(&self) -> &str;
+}

--- a/crates/hexafn-run/src/domain/contracts/mod.rs
+++ b/crates/hexafn-run/src/domain/contracts/mod.rs
@@ -1,0 +1,2 @@
+// SPDX-FileCopyrightText: 2025 Husamettin ARABACI
+// SPDX-License-Identifier: MIT

--- a/crates/hexafn-store/src/domain/contracts/kv_store.rs
+++ b/crates/hexafn-store/src/domain/contracts/kv_store.rs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2025 Husamettin ARABACI
+// SPDX-License-Identifier: MIT
+
+/// Trait for a generic key-value store contract.
+pub trait KvStore {
+    fn get(&self, namespace: &str, key: &str) -> Option<Vec<u8>>;
+    fn put(&mut self, namespace: &str, key: &str, value: Vec<u8>);
+    fn delete(&mut self, namespace: &str, key: &str);
+}

--- a/crates/hexafn-store/src/domain/contracts/mod.rs
+++ b/crates/hexafn-store/src/domain/contracts/mod.rs
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: 2025 Husamettin ARABACI
+// SPDX-License-Identifier: MIT
+
+pub mod kv_store;

--- a/crates/hexafn-watch/src/domain/contracts/mod.rs
+++ b/crates/hexafn-watch/src/domain/contracts/mod.rs
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: 2025 Husamettin ARABACI
+// SPDX-License-Identifier: MIT
+
+pub mod trace;

--- a/crates/hexafn-watch/src/domain/contracts/trace.rs
+++ b/crates/hexafn-watch/src/domain/contracts/trace.rs
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Husamettin ARABACI
+// SPDX-License-Identifier: MIT
+
+/// Trait for distributed tracing.
+pub trait Trace {
+    fn start_span(&self, name: &str);
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -105,7 +105,7 @@ All stages can independently be observed, tested, logged, and extended.
 
 ## 📦 File Structure (Planned)
 
-➡️ [`PROJECT_STRUCTURE.md`](PROJECT_STRUCTURE.md) – Directory structure and module breakdown
+➡️ [PROJECT_STRUCTURE](PROJECT_STRUCTURE.md) – Directory structure and module breakdown
 
 ---
 

--- a/docs/COMMUNITY.md
+++ b/docs/COMMUNITY.md
@@ -27,12 +27,12 @@ Welcome to the hexaFn community! This document outlines how to participate respe
 
 ## ✅ Tips for Contribution
 
-- Read the [`CONTRIBUTING.md`](CONTRIBUTING.md) guide before submitting issues or PRs.
+- Read the [CONTRIBUTING](CONTRIBUTING.md) guide before submitting issues or PRs.
 - Use English for all communications to keep the project inclusive.
 - Label your contributions clearly and use commit conventions.
 
 ## 📧 Need Help?
 
-Reach out via [GitHub Issues](https://github.com/hTuneSys/hexaFn/issues) or check the [`SUPPORT.md`](SUPPORT.md) for assistance.
+Reach out via [GitHub Issues](https://github.com/hTuneSys/hexaFn/issues) or check the [SUPPORT](SUPPORT.md) for assistance.
 
 Thank you for being part of hexaFn! We value your contributions and presence.

--- a/docs/CONTACT.md
+++ b/docs/CONTACT.md
@@ -31,7 +31,7 @@ For bug reports, feature requests, or support questions, please use our [GitHub 
 
 ## 🔒 Security Reports
 
-If you discover a security vulnerability, please follow the guidelines in [SECURITY.md](../.github/SECURITY.md) or contact us securely at:
+If you discover a security vulnerability, please follow the guidelines in [SECURITY](../.github/SECURITY.md) or contact us securely at:
 
 - Email: [info@hexafn.com](mailto:info@hexafn.com)
 
@@ -49,8 +49,8 @@ For sponsorships, collaborations, or media inquiries, please see our [FUNDING.ym
 
 If you're interested in contributing, collaborating, or joining the discussion:
 
-- Read the [CONTRIBUTING.md](../.github/CONTRIBUTING.md)
-- Follow our [CODE_OF_CONDUCT.md](../.github/CODE_OF_CONDUCT.md)
+- Read the [CONTRIBUTING](../.github/CONTRIBUTING.md)
+- Follow our [CODE_OF_CONDUCT](../.github/CODE_OF_CONDUCT.md)
 - Join community discussions on GitHub
 
 ---

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -3,105 +3,106 @@ SPDX-FileCopyrightText: 2025 Husamettin ARABACI
 SPDX-License-Identifier: MIT
 -->
 
-# 📊 hexaFn Data Flow Example
+# 📊 hexaFn Data Flow Overview
 
-This diagram illustrates the complete data flow through all hexaFn modules, organized according to the **6F Lifecycle Phases** and **Hexagonal Architecture layers**.
+This diagram provides a high-level architectural overview of the hexaFn project, showing the relationships and data flows between all main modules and their interaction with external systems. It is designed to align with the 6F Lifecycle Flow (**Feed → Filter → Format → Function → Forward → Feedback**) and the Hexagonal Architecture principles. For detailed component-level diagrams, see `DATA_FLOW_DETAIL.md`.
 
-## 🔄 Complete Flow Diagram
+---
+
+## 🔄 High-Level Architecture Diagram
 
 ```mermaid
 flowchart TB
     %% External Systems
-    External[External Systems] --> BridgeInfra
-    
-    %% Bridge Modülü
-    subgraph Bridge["hexafn-bridge (Feed Phase)"]
-        BridgeInfra["Infrastructure Layer (Controller, Parser)"] --> BridgeApp
-        BridgeApp["Application Layer (WebhookIngestionPort)"] --> BridgeDomain
-        BridgeDomain["Domain Layer (WebhookEvent)"] --> BridgeOutInfra
-        BridgeOutInfra["Infrastructure Layer (EventPublisher)"] --> TopicRouter
+    External["External Systems<br/>(Webhooks, APIs, Clients, Queues)"]
+
+    %% Feed Phase: Bridge Module
+    subgraph Bridge["hexafn-bridge (Feed)"]
+        BridgeInfra["Infrastructure Layer<br/>(Webhook Endpoints, SDKs, API Clients)"]
+        BridgeApp["Application Layer<br/>(IntegrationManagementPort, WebhookReceiverPort)"]
+        BridgeDomain["Domain Layer<br/>(Integration, Webhook, EventTransformer)"]
     end
-    
-    %% Trigger Modülü
-    subgraph Trigger["hexafn-trigger (Filter Phase)"]
-        TriggerInfra["Infrastructure Layer (EventSubscriber)"] --> TriggerApp
-        TriggerApp["Application Layer (TriggerEvaluationPort)"] --> TriggerDomain
-        TriggerDomain["Domain Layer (Trigger, Rules)"] --> TriggerOutInfra
-        TriggerOutInfra["Infrastructure Layer (ExecutionRequestPublisher)"] --> ExecRequest
+
+    %% Filter Phase: Trigger Module
+    subgraph Trigger["hexafn-trigger (Filter)"]
+        TriggerInfra["Infrastructure Layer<br/>(EventSubscriber, ConfigLoader)"]
+        TriggerApp["Application Layer<br/>(TriggerRegistryPort, TriggerEvaluationPort)"]
+        TriggerDomain["Domain Layer<br/>(Trigger, TriggerCondition, CompoundType)"]
     end
-    
-    %% Run Modülü
-    subgraph Run["hexafn-run (Format & Function Phases)"]
-        RunInfra["Infrastructure Layer (ExecutionSubscriber)"] --> RunApp
-        RunApp["Application Layer (FunctionExecutionPort)"] --> RunDomain
-        RunDomain["Domain Layer (Function, Schema)"] --> RunOutInfra
-        RunOutInfra["Infrastructure Layer (RuntimeImpls, ResultPublisher)"] --> Results
+
+    %% Format & Function Phase: Run Module
+    subgraph Run["hexafn-run (Format & Function)"]
+        RunInfra["Infrastructure Layer<br/>(ExecutionSubscriber, FunctionRepository)"]
+        RunApp["Application Layer<br/>(FunctionRegistryPort, FunctionExecutionPort)"]
+        RunDomain["Domain Layer<br/>(FunctionRuntime, FunctionContext, ExecutionResult)"]
     end
-    
-    %% Forward Phase
-    subgraph Forward["Forward Phase"]
-        %% Store Modülü
-        subgraph Store["hexafn-store"]
-            StoreInfra["Infrastructure Layer (KVStoreController)"] --> StoreApp
-            StoreApp["Application Layer (KVStorePort)"] --> StoreDomain
-            StoreDomain["Domain Layer (KVPair, Key, Value)"] --> StoreOutInfra
-            StoreOutInfra["Infrastructure Layer (StorageImpls)"] --> Storage
-        end
-        
-        %% Cast Modülü
-        subgraph Cast["hexafn-cast"]
-            CastInfra["Infrastructure Layer (Controllers)"] --> CastApp
-            CastApp["Application Layer (PublisherPort, SubscriberPort)"] --> CastDomain
-            CastDomain["Domain Layer (Topic, Message, Subscriber)"] --> CastOutInfra
-            CastOutInfra["Infrastructure Layer (MessageBus)"] --> Subscribers
-        end
+
+    %% Forward Phase: Store & Cast Modules
+    subgraph Store["hexafn-store (Forward: KV Store)"]
+        StoreInfra["Infrastructure Layer<br/>(KVStoreController, StoreRepository)"]
+        StoreApp["Application Layer<br/>(KvStorePort, StoreService)"]
+        StoreDomain["Domain Layer<br/>(KvStore, KeyValueEntry, Namespace)"]
     end
-    
-    %% Watch Modülü
-    subgraph Watch["hexafn-watch (Feedback Phase)"]
-        WatchInfra["Infrastructure Layer (Endpoints, Hooks)"] --> WatchApp
-        WatchApp["Application Layer (LoggingPort, TracingPort, MetricsPort)"] --> WatchDomain
-        WatchDomain["Domain Layer (Trace, Span, LogEntry, MetricPoint)"] --> WatchOutInfra
-        WatchOutInfra["Infrastructure Layer (Exporters)"] --> Monitoring
+
+    subgraph Cast["hexafn-cast (Forward: Pub/Sub)"]
+        CastInfra["Infrastructure Layer<br/>(Controllers, MessageBus)"]
+        CastApp["Application Layer<br/>(PublisherPort, SubscriberPort)"]
+        CastDomain["Domain Layer<br/>(Topic, Message, Subscriber)"]
     end
-    
-    %% Core Modülü
+
+    %% Feedback Phase: Watch Module
+    subgraph Watch["hexafn-watch (Feedback)"]
+        WatchInfra["Infrastructure Layer<br/>(Endpoints, Exporters)"]
+        WatchApp["Application Layer<br/>(LoggingPort, TracingPort, MetricsPort)"]
+        WatchDomain["Domain Layer<br/>(Trace, Span, LogEntry, MetricPoint)"]
+    end
+
+    %% Core Module (Shared Kernel)
     subgraph Core["hexafn-core (Shared Kernel)"]
-        CoreDomain["Domain Layer (DomainEvent, ValueObjects)"]
-        CoreApp["Application Layer (6F Lifecycle Traits)"]
-        CoreInfra["Infrastructure Layer (EventBus, Config)"]
+        CoreDomain["Domain Layer<br/>(DomainEvent, ValueObjects, Pipeline)"]
+        CoreApp["Application Layer<br/>(6F Lifecycle Traits, Orchestrator)"]
+        CoreInfra["Infrastructure Layer<br/>(EventBus, Config, CLI)"]
     end
-    
-    %% Bağlantılar
-    TopicRouter --> TriggerInfra
-    ExecRequest --> RunInfra
-    Results --> StoreInfra
-    Results --> CastInfra
-    Storage --> WatchInfra
-    Subscribers --> WatchInfra
-    Monitoring --> External
-    
-    %% Core bağlantıları
+
+    %% Data Flow Connections (6F Lifecycle)
+    External --> BridgeInfra
+    BridgeInfra --> BridgeApp --> BridgeDomain
+    BridgeDomain --> TriggerInfra
+    TriggerInfra --> TriggerApp --> TriggerDomain
+    TriggerDomain --> RunInfra
+    RunInfra --> RunApp --> RunDomain
+    RunDomain --> StoreInfra
+    RunDomain --> CastInfra
+    StoreInfra --> StoreApp --> StoreDomain
+    CastInfra --> CastApp --> CastDomain
+    StoreDomain --> WatchInfra
+    CastDomain --> WatchInfra
+    WatchInfra --> WatchApp --> WatchDomain
+    WatchDomain --> CoreInfra
+
+    %% Feedback/Observability
+    WatchDomain --> External
+
+    %% Core Module Relationships
     CoreDomain -.-> BridgeDomain & TriggerDomain & RunDomain & StoreDomain & CastDomain & WatchDomain
     CoreApp -.-> BridgeApp & TriggerApp & RunApp & StoreApp & CastApp & WatchApp
     CoreInfra -.-> BridgeInfra & TriggerInfra & RunInfra & StoreInfra & CastInfra & WatchInfra
+
+    %% Bidirectional/Orchestration
+    CoreApp -.-> CoreInfra
+    CoreInfra -.-> CoreApp
 ```
+
+---
 
 ## 📑 Flow Explanation
 
-This diagram shows how data flows through the complete hexaFn system following the **6F Lifecycle Flow**:
+- **External Systems** send events or requests to the system via the **Bridge** module (Feed phase).
+- **Bridge** normalizes and ingests events, passing them to the **Trigger** module (Filter phase).
+- **Trigger** evaluates conditions and rules, forwarding valid events to the **Run** module (Format & Function phases).
+- **Run** executes user-defined logic/functions, producing results that are sent to **Store** (for persistence) and/or **Cast** (for pub/sub/event broadcasting) in the Forward phase.
+- **Store** and **Cast** modules can both emit events or state changes to the **Watch** module (Feedback phase), which handles logging, tracing, and metrics.
+- **Watch** provides observability and can export feedback to external monitoring systems.
+- The **Core** module provides shared types, orchestration, and event bus infrastructure, supporting all other modules and ensuring architectural consistency.
 
-1. **Feed** (hexafn-bridge): External systems send data to the Bridge module, which ingests it
-2. **Filter** (hexafn-trigger): The Trigger module evaluates conditions and rules on the data
-3. **Format & Function** (hexafn-run): The Run module formats data and executes the appropriate function
-4. **Forward** (hexafn-store, hexafn-cast): Results are forwarded to storage or messaging systems
-5. **Feedback** (hexafn-watch): The Watch module provides observability and monitoring
-
-The **hexafn-core** module acts as a shared kernel, providing common functionality to all other modules.
-
-Each module follows **Hexagonal Architecture** with clearly separated:
-- Infrastructure Layer (adapters for external systems)
-- Application Layer (use cases and ports)
-- Domain Layer (business logic and entities)
-
-This architecture ensures that business logic is decoupled from external concerns and can be tested independently.
+This high-level diagram ensures clear separation of concerns, strict module boundaries, and a unidirectional data flow that follows the 6F Lifecycle Flow. For detailed component and interface relationships, see `DATA_FLOW_DETAIL.md`.

--- a/docs/DATA_MODEL_BRIDGE.md
+++ b/docs/DATA_MODEL_BRIDGE.md
@@ -71,6 +71,73 @@ classDiagram
     Webhook --> Response
     BridgeEvent <|-- WebhookReceivedEvent
     BridgeEvent <|-- IntegrationRegisteredEvent
+    %% Additional missing domain structures from output.txt
+    class BridgeAuditTrail {
+        +bridge_id String
+        +events Vec~BridgeAuditEvent~
+    }
+    class BridgeLock {
+        +acquire(id: String) Result~_, HexaError~
+        +release(id: String) Result~_, HexaError~
+        +is_locked(id: String) bool
+    }
+    class BridgeDependencyGraph {
+        +add_dependency(from: String, to: String)
+        +remove_dependency(from: String, to: String)
+        +get_dependencies(id: String) Vec~String~
+    }
+    class BridgeRollbackPoint {
+        +bridge_id String
+        +stage_index u32
+        +state serde_json::Value
+    }
+    class BridgeTag {
+        +name String
+        +color String
+    }
+    class BridgeAccessControl {
+        +bridge_id String
+        +allowed_roles Vec~String~
+        +is_allowed(user: String) bool
+    }
+    class IntegrationHealthCheck {
+        +integration_id String
+        +status String
+        +last_checked DateTime
+    }
+    class IntegrationRetryPolicy {
+        +integration_id String
+        +max_retries u32
+        +backoff_strategy String
+    }
+    class IntegrationCircuitBreaker {
+        +integration_id String
+        +state String
+        +failure_count u32
+        +reset_timeout Duration
+    }
+    class IntegrationRateLimit {
+        +integration_id String
+        +limit u32
+        +window Duration
+    }
+    class IntegrationTransformationTemplate {
+        +integration_id String
+        +template String
+    }
+    class IntegrationApprovalWorkflow {
+        +integration_id String
+        +steps Vec~String~
+        +status String
+    }
+    class IntegrationSecretManager {
+        +integration_id String
+        +secrets HashMap~String, String~
+    }
+    class IntegrationAuditTrail {
+        +integration_id String
+        +calls Vec~IntegrationCallEvent~
+    }
 ```
 
 ## Application Layer
@@ -117,6 +184,33 @@ classDiagram
     BridgeService --> IntegrationManagementPort
     BridgeService --> WebhookReceiverPort
     IntegrationConfigLoader --> IntegrationConfig
+    %% Additional missing application structures from output.txt
+    class BridgeAuditService {
+        +record_event(bridge_id: String, event: BridgeAuditEvent)
+        +get_audit_trail(bridge_id: String) BridgeAuditTrail
+    }
+    class BridgeLockService {
+        +lock(bridge_id: String) Result~_, HexaError~
+        +unlock(bridge_id: String) Result~_, HexaError~
+        +is_locked(bridge_id: String) bool
+    }
+    class BridgeDependencyService {
+        +resolve_dependencies(bridge_id: String) Vec~String~
+    }
+    class BridgeRollbackService {
+        +create_rollback_point(bridge_id: String, stage_index: u32)
+        +rollback_to_point(bridge_id: String, point: BridgeRollbackPoint)
+    }
+    class BridgeTaggingService {
+        +add_tag(bridge_id: String, tag: BridgeTag)
+        +remove_tag(bridge_id: String, tag: BridgeTag)
+        +list_tags(bridge_id: String) Vec~BridgeTag~
+    }
+    class BridgeAccessControlService {
+        +grant_access(bridge_id: String, user: String)
+        +revoke_access(bridge_id: String, user: String)
+        +check_access(bridge_id: String, user: String) bool
+    }
 ```
 
 ## Infrastructure Layer
@@ -149,6 +243,32 @@ classDiagram
     BridgeEventBus --> BridgeEvent
     BridgeMapper --> IntegrationDto
     BridgeMapper --> Integration
+    %% Additional missing infrastructure structures from output.txt
+    class BridgeAuditRepository {
+        +save(trail: BridgeAuditTrail)
+        +load(bridge_id: String) Option~BridgeAuditTrail~
+    }
+    class BridgeLockManager {
+        +acquire_lock(bridge_id: String)
+        +release_lock(bridge_id: String)
+        +is_locked(bridge_id: String) bool
+    }
+    class BridgeDependencyAdapter {
+        +fetch_dependencies(bridge_id: String) Vec~String~
+    }
+    class BridgeRollbackAdapter {
+        +save_point(point: BridgeRollbackPoint)
+        +load_points(bridge_id: String) Vec~BridgeRollbackPoint~
+    }
+    class BridgeTagStore {
+        +add(bridge_id: String, tag: BridgeTag)
+        +remove(bridge_id: String, tag: BridgeTag)
+        +list(bridge_id: String) Vec~BridgeTag~
+    }
+    class BridgeAccessControlAdapter {
+        +set_access(bridge_id: String, user: String, allowed: bool)
+        +get_access(bridge_id: String, user: String) bool
+    }
 ```
 
 ---

--- a/docs/DATA_MODEL_TRIGGER.md
+++ b/docs/DATA_MODEL_TRIGGER.md
@@ -55,6 +55,34 @@ classDiagram
         +trigger_id String
         +timestamp DateTime
     }
+    class TriggerAuditTrail {
+        +trigger_id String
+        +events Vec~TriggerAuditEvent~
+    }
+    class TriggerLock {
+        +acquire(id: String) Result~_, HexaError~
+        +release(id: String) Result~_, HexaError~
+        +is_locked(id: String) bool
+    }
+    class TriggerDependencyGraph {
+        +add_dependency(from: String, to: String)
+        +remove_dependency(from: String, to: String)
+        +get_dependencies(id: String) Vec~String~
+    }
+    class TriggerRollbackPoint {
+        +trigger_id String
+        +stage_index u32
+        +state serde_json::Value
+    }
+    class TriggerTag {
+        +name String
+        +color String
+    }
+    class TriggerAccessControl {
+        +trigger_id String
+        +allowed_roles Vec~String~
+        +is_allowed(user: String) bool
+    }
     Trigger --> TriggerCondition
     TriggerEvent <|-- TriggerCreatedEvent
     TriggerEvent <|-- TriggerFiredEvent
@@ -115,6 +143,32 @@ classDiagram
         +params serde_json::Value
         +compound CompoundType
     }
+    class TriggerAuditService {
+        +record_event(trigger_id: String, event: TriggerAuditEvent)
+        +get_audit_trail(trigger_id: String) TriggerAuditTrail
+    }
+    class TriggerLockService {
+        +lock(trigger_id: String) Result~_, HexaError~
+        +unlock(trigger_id: String) Result~_, HexaError~
+        +is_locked(trigger_id: String) bool
+    }
+    class TriggerDependencyService {
+        +resolve_dependencies(trigger_id: String) Vec~String~
+    }
+    class TriggerRollbackService {
+        +create_rollback_point(trigger_id: String, stage_index: u32)
+        +rollback_to_point(trigger_id: String, point: TriggerRollbackPoint)
+    }
+    class TriggerTaggingService {
+        +add_tag(trigger_id: String, tag: TriggerTag)
+        +remove_tag(trigger_id: String, tag: TriggerTag)
+        +list_tags(trigger_id: String) Vec~TriggerTag~
+    }
+    class TriggerAccessControlService {
+        +grant_access(trigger_id: String, user: String)
+        +revoke_access(trigger_id: String, user: String)
+        +check_access(trigger_id: String, user: String) bool
+    }
     TriggerRegistryPort --> Trigger
     TriggerEvaluationPort --> Trigger
     TriggerService --> TriggerRegistryPort
@@ -151,10 +205,33 @@ classDiagram
         +to_dto(trigger: Trigger) TriggerDto
         +from_dto(dto: TriggerDto) Trigger
     }
+    class TriggerAuditRepository {
+        +save(trail: TriggerAuditTrail)
+        +load(trigger_id: String) Option~TriggerAuditTrail~
+    }
+    class TriggerLockManager {
+        +acquire_lock(trigger_id: String)
+        +release_lock(trigger_id: String)
+        +is_locked(trigger_id: String) bool
+    }
+    class TriggerDependencyAdapter {
+        +fetch_dependencies(trigger_id: String) Vec~String~
+    }
+    class TriggerRollbackAdapter {
+        +save_point(point: TriggerRollbackPoint)
+        +load_points(trigger_id: String) Vec~TriggerRollbackPoint~
+    }
+    class TriggerTagStore {
+        +add(trigger_id: String, tag: TriggerTag)
+        +remove(trigger_id: String, tag: TriggerTag)
+        +list(trigger_id: String) Vec~TriggerTag~
+    }
+    class TriggerAccessControlAdapter {
+        +set_access(trigger_id: String, user: String, allowed: bool)
+        +get_access(trigger_id: String, user: String) bool
+    }
     TriggerRepository --> Trigger
     TriggerEventBus --> TriggerEvent
     TriggerMapper --> TriggerDto
     TriggerMapper --> Trigger
 ```
-
----

--- a/docs/DATA_MODEL_WATCH.md
+++ b/docs/DATA_MODEL_WATCH.md
@@ -55,6 +55,67 @@ classDiagram
         +timestamp DateTime
         +message String
     }
+    %% Additional missing domain structures from output.txt
+    class WatchAuditTrail {
+        +watch_id String
+        +events Vec~WatchAuditEvent~
+    }
+    class WatchLock {
+        +acquire(id: String) Result~_, HexaError~
+        +release(id: String) Result~_, HexaError~
+        +is_locked(id: String) bool
+    }
+    class WatchDependencyGraph {
+        +add_dependency(from: String, to: String)
+        +remove_dependency(from: String, to: String)
+        +get_dependencies(id: String) Vec~String~
+    }
+    class WatchRollbackPoint {
+        +watch_id String
+        +stage_index u32
+        +state serde_json::Value
+    }
+    class WatchTag {
+        +name String
+        +color String
+    }
+    class WatchAccessControl {
+        +watch_id String
+        +allowed_roles Vec~String~
+        +is_allowed(user: String) bool
+    }
+    class LogRedaction {
+        +redact(entry: LogEntry) LogEntry
+    }
+    class LogRetentionPolicy {
+        +max_age Duration
+        +max_size u64
+    }
+    class LogExporters {
+        +export(entry: LogEntry, target: String) Result~_, HexaError~
+    }
+    class TraceCorrelation {
+        +correlate(trace_ids: Vec~String~) Result~_, HexaError~
+    }
+    class TraceSamplingPolicy {
+        +sample(trace: Trace) bool
+    }
+    class AlertSuppression {
+        +suppress(alert_id: String) bool
+    }
+    class AlertEscalation {
+        +escalate(alert_id: String) void
+    }
+    class MetricsDownsampling {
+        +downsample(points: Vec~MetricPoint~) Vec~MetricPoint~
+    }
+    class MetricsCustomAggregator {
+        +aggregate(points: Vec~MetricPoint~) MetricPoint
+    }
+    class WatchAccessAudit {
+        +audit_id String
+        +access_events Vec~WatchAccessEvent~
+    }
     Trace --> Span
     LogEntry --> LogLevel
     MetricPoint --> LogEntry
@@ -107,6 +168,33 @@ classDiagram
         +GetTrace
         +GetMetrics
     }
+    %% Additional missing application structures from output.txt
+    class WatchAuditService {
+        +record_event(watch_id: String, event: WatchAuditEvent)
+        +get_audit_trail(watch_id: String) WatchAuditTrail
+    }
+    class WatchLockService {
+        +lock(watch_id: String) Result~_, HexaError~
+        +unlock(watch_id: String) Result~_, HexaError~
+        +is_locked(watch_id: String) bool
+    }
+    class WatchDependencyService {
+        +resolve_dependencies(watch_id: String) Vec~String~
+    }
+    class WatchRollbackService {
+        +create_rollback_point(watch_id: String, stage_index: u32)
+        +rollback_to_point(watch_id: String, point: WatchRollbackPoint)
+    }
+    class WatchTaggingService {
+        +add_tag(watch_id: String, tag: WatchTag)
+        +remove_tag(watch_id: String, tag: WatchTag)
+        +list_tags(watch_id: String) Vec~WatchTag~
+    }
+    class WatchAccessControlService {
+        +grant_access(watch_id: String, user: String)
+        +revoke_access(watch_id: String, user: String)
+        +check_access(watch_id: String, user: String) bool
+    }
     LoggingPort --> LogEntry
     TracingPort --> Trace
     MetricsPort --> MetricPoint
@@ -143,11 +231,35 @@ classDiagram
         +to_dto(entry: LogEntry) WatchDto
         +from_dto(dto: WatchDto) LogEntry
     }
+    %% Additional missing infrastructure structures from output.txt
+    class WatchAuditRepository {
+        +save(trail: WatchAuditTrail)
+        +load(watch_id: String) Option~WatchAuditTrail~
+    }
+    class WatchLockManager {
+        +acquire_lock(watch_id: String)
+        +release_lock(watch_id: String)
+        +is_locked(watch_id: String) bool
+    }
+    class WatchDependencyAdapter {
+        +fetch_dependencies(watch_id: String) Vec~String~
+    }
+    class WatchRollbackAdapter {
+        +save_point(point: WatchRollbackPoint)
+        +load_points(watch_id: String) Vec~WatchRollbackPoint~
+    }
+    class WatchTagStore {
+        +add(watch_id: String, tag: WatchTag)
+        +remove(watch_id: String, tag: WatchTag)
+        +list(watch_id: String) Vec~WatchTag~
+    }
+    class WatchAccessControlAdapter {
+        +set_access(watch_id: String, user: String, allowed: bool)
+        +get_access(watch_id: String, user: String) bool
+    }
     LogExporter --> LogEntry
     TraceExporter --> Trace
     MetricsExporter --> MetricPoint
     WatchMapper --> WatchDto
     WatchMapper --> LogEntry
 ```
-
----

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -11,7 +11,7 @@ This guide helps developers understand how to work with the hexaFn project. It e
 
 ## 🗂️ Project Structure
 
-- [`PROJECT_STRUCTURE.md`](PROJECT_STRUCTURE.md) – Directory structure
+- [PROJECT_STRUCTURE](PROJECT_STRUCTURE.md) – Directory structure
 
 ---
 
@@ -96,7 +96,7 @@ For detailed tracing, integrate with `HexaWatch` logging module.
 
 ## 🔀 Branching & PRs
 
-Follow the naming rules defined in [`BRANCH_STRATEGY.md`](BRANCH_STRATEGY.md) and [`PR_STRATEGY.md`](PR_STRATEGY.md). Allowed branch prefixes:
+Follow the naming rules defined in [BRANCH_STRATEGY](BRANCH_STRATEGY.md) and [PR_STRATEGY](PR_STRATEGY.md). Allowed branch prefixes:
 
 - `feat/`, `fix/`, `refactor/`, `test/`, `docs/`, `ci/`, etc.
 
@@ -106,13 +106,13 @@ Create a feature branch:
 git checkout -b feat/new-module
 ```
 
-Open a PR with a valid title and follow checklist from [`PULL_REQUEST_TEMPLATE.md`](../.github/PULL_REQUEST_TEMPLATE.md).
+Open a PR with a valid title and follow checklist from [PULL_REQUEST_TEMPLATE](../.github/PULL_REQUEST_TEMPLATE.md).
 
 ---
 
 ## 🧱 Commit Conventions
 
-Use the supported 12 types from [`COMMIT_STRATEGY.md`](COMMIT_STRATEGY.md). Example:
+Use the supported 12 types from [COMMIT_STRATEGY](COMMIT_STRATEGY.md). Example:
 
 ```bash
 feat: add token parsing logic
@@ -147,17 +147,17 @@ Branches like `main`, `release`, and `develop` are protected:
 
 Understanding hexaFn's architecture is essential for effective development. Review these key documents:
 
-- [`HEXAGONAL_ARCHITECTURE_GUIDE.md`](HEXAGONAL_ARCHITECTURE_GUIDE.md) - Fundamental hexagonal architecture principles
-- [`RUST_PORTS_ADAPTERS_EXAMPLE.md`](RUST_PORTS_ADAPTERS_EXAMPLE.md) - Comprehensive component catalog organized by architectural layers
-- [`DATA_FLOW.md`](DATA_FLOW.md) - High-level data flow diagram across all modules
-- [`DATA_FLOW_DETAIL.md`](DATA_FLOW_DETAIL.md) - Detailed component interactions with interfaces and methods
-- [`DATA_MODEL_CORE.md`](DATA_MODEL_CORE.md) - Core data model definitions
-- [`DATA_MODEL_RUN.md`](DATA_MODEL_RUN.md) - Run data model definitions
-- [`DATA_MODEL_CAST.md`](DATA_MODEL_CAST.md) - Cast data model definitions
-- [`DATA_MODEL_BRIDGE.md`](DATA_MODEL_BRIDGE.md) - Bridge data model definitions
-- [`DATA_MODEL_TRIGGER.md`](DATA_MODEL_TRIGGER.md) - Trigger data model definitions
-- [`DATA_MODEL_STORE.md`](DATA_MODEL_STORE.md) - Store data model definitions
-- [`DATA_MODEL_WATCH.md`](DATA_MODEL_WATCH.md) - Watch data model definitions
+- [HEXAGONAL_ARCHITECTURE_GUIDE](HEXAGONAL_ARCHITECTURE_GUIDE.md) - Fundamental hexagonal architecture principles
+- [RUST_PORTS_ADAPTERS_EXAMPLE](RUST_PORTS_ADAPTERS_EXAMPLE.md) - Comprehensive component catalog organized by architectural layers
+- [DATA_FLOW](DATA_FLOW.md) - High-level data flow diagram across all modules
+- [DATA_FLOW_DETAIL](DATA_FLOW_DETAIL.md) - Detailed component interactions with interfaces and methods
+- [DATA_MODEL_CORE](DATA_MODEL_CORE.md) - Core data model definitions
+- [DATA_MODEL_RUN](DATA_MODEL_RUN.md) - Run data model definitions
+- [DATA_MODEL_CAST](DATA_MODEL_CAST.md) - Cast data model definitions
+- [DATA_MODEL_BRIDGE](DATA_MODEL_BRIDGE.md) - Bridge data model definitions
+- [DATA_MODEL_TRIGGER](DATA_MODEL_TRIGGER.md) - Trigger data model definitions
+- [DATA_MODEL_STORE](DATA_MODEL_STORE.md) - Store data model definitions
+- [DATA_MODEL_WATCH](DATA_MODEL_WATCH.md) - Watch data model definitions
 
 These documents explain how components interact across the 6F Lifecycle Flow (Feed → Filter → Format → Function → Forward → Feedback) following clean hexagonal architecture patterns.
 
@@ -178,21 +178,21 @@ All contributors must follow the documentation style and structure:
 
 - Use `///` for public Rust docs
 - Update relevant `.md` files in `docs/` when modifying features
-- Follow the guide in [`CONTRIBUTING.md`](CONTRIBUTING.md)
+- Follow the guide in [CONTRIBUTING](CONTRIBUTING.md)
 
 ---
 
 ## 🧠 Helpful Resources
 
-- [`GETTING_STARTED.md`](GETTING_STARTED.md) – Initial setup and quick commands
-- [`HEXAGONAL_ARCHITECTURE_GUIDE.md`](HEXAGONAL_ARCHITECTURE_GUIDE.md) - Protocol-agnostic implementation patterns and data flow
-- [`ARCHITECTURE.md`](ARCHITECTURE.md) – System design and modules
-- [`USE_CASES.md`](USE_CASES.md) – Functional capabilities
-- [`CONTACT.md`](CONTACT.md), [`SUPPORT.md`](SUPPORT.md) – Communication channels
-- [`LABELLING_STRATEGY.md`](LABELLING_STRATEGY.md) – Tag issues/PRs correctly
-- [`PROJECT_STRUCTURE.md`](PROJECT_STRUCTURE.md) – Directory structure
-- [`BRANCH_STRATEGY.md`](BRANCH_STRATEGY.md) – Branch naming conventions
-- [`COMMIT_STRATEGY.md`](COMMIT_STRATEGY.md) – Commit message conventions
+- [GETTING_STARTED](GETTING_STARTED.md) – Initial setup and quick commands
+- [HEXAGONAL_ARCHITECTURE_GUIDE](HEXAGONAL_ARCHITECTURE_GUIDE.md) - Protocol-agnostic implementation patterns and data flow
+- [ARCHITECTURE](ARCHITECTURE.md) – System design and modules
+- [USE_CASES](USE_CASES.md) – Functional capabilities
+- [CONTACT](CONTACT.md), [SUPPORT](SUPPORT.md) – Communication channels
+- [LABELLING_STRATEGY](LABELLING_STRATEGY.md) – Tag issues/PRs correctly
+- [PROJECT_STRUCTURE](PROJECT_STRUCTURE.md) – Directory structure
+- [BRANCH_STRATEGY](BRANCH_STRATEGY.md) – Branch naming conventions
+- [COMMIT_STRATEGY](COMMIT_STRATEGY.md) – Commit message conventions
 
 ---
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -23,13 +23,13 @@ It is a utility library with optional CLI tools. It is **not** a web framework o
 
 ## ❓ How do I get started?
 
-Refer to the [`GETTING_STARTED.md`](GETTING_STARTED.md) file (coming soon). It will walk you through setup, commands, and examples.
+Refer to the [GETTING_STARTED](GETTING_STARTED.md) file (coming soon). It will walk you through setup, commands, and examples.
 
 ---
 
 ## ❓ How can I contribute?
 
-Check out the [`CONTRIBUTING.md`](CONTRIBUTING.md) for instructions on how to suggest changes, report issues, and submit pull requests.
+Check out the [CONTRIBUTING](CONTRIBUTING.md) for instructions on how to suggest changes, report issues, and submit pull requests.
 
 ---
 
@@ -37,7 +37,7 @@ Check out the [`CONTRIBUTING.md`](CONTRIBUTING.md) for instructions on how to su
 
 Yes. You must:
 
-- Follow the commit message strategy defined in [`COMMIT_STRATEGY.md`](COMMIT_STRATEGY.md)
+- Follow the commit message strategy defined in [COMMIT_STRATEGY](COMMIT_STRATEGY.md)
 - Respect the branching and PR rules
 - Adhere to the code of conduct
 
@@ -57,7 +57,7 @@ Use the [Feature Request Template](https://github.com/hTuneSys/hexaFn/issues/new
 
 ## ❓ How is this project licensed?
 
-hexaFn is licensed under the MIT License. See the [`LICENSE`](https://github.com/hTuneSys/hexaFn/blob/develop/LICENSE) file for more details.
+hexaFn is licensed under the MIT License. See the [LICENSE](https://github.com/hTuneSys/hexaFn/blob/develop/LICENSE) file for more details.
 
 ---
 
@@ -73,7 +73,7 @@ You can:
 
 - Open a GitHub Discussion
 - File an issue using the Support template
-- Refer to the [`SUPPORT.md`](SUPPORT.md) and [`CONTACT.md`](CONTACT.md) files
+- Refer to the [SUPPORT](SUPPORT.md) and [CONTACT](CONTACT.md) files
 
 ---
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -91,9 +91,9 @@ cargo clippy
 
 ## 📚 Next Steps
 
-- Check [`ARCHITECTURE.md`](ARCHITECTURE.md) to understand system design
-- Use [`USE_CASES.md`](USE_CASES.md) to explore core functionalities
-- Review [`CONTRIBUTING.md`](CONTRIBUTING.md) to contribute effectively
+- Check [ARCHITECTURE](ARCHITECTURE.md) to understand system design
+- Use [USE_CASES](USE_CASES.md) to explore core functionalities
+- Review [CONTRIBUTING](CONTRIBUTING.md) to contribute effectively
 
 ---
 

--- a/docs/PROJECT_BOARD.md
+++ b/docs/PROJECT_BOARD.md
@@ -57,4 +57,4 @@ GitHub Actions and project workflows automate the board:
 ## 🔗 Access the Board
 
 Visit the live project board here:  
-➡️ [`BOARD`](https://github.com/orgs/hTuneSys/projects/15/views/1)
+➡️ [BOARD](https://github.com/orgs/hTuneSys/projects/15/views/1)

--- a/docs/RUST_PORTS_ADAPTERS_EXAMPLE.md
+++ b/docs/RUST_PORTS_ADAPTERS_EXAMPLE.md
@@ -3,337 +3,458 @@ SPDX-FileCopyrightText: 2025 Husamettin ARABACI
 SPDX-License-Identifier: MIT
 -->
 
-# Rust Ports & Adapters Components Documentation
+# Rust Ports & Adapters Components Documentation (hexaFn)
 
-This document provides a comprehensive, table-based overview of all ports, adapters, and domain components implemented in hexaFn's Hexagonal Architecture pattern. Each table maps to a specific module and its corresponding architecture layers.
+This document provides a comprehensive, module-by-module, layer-by-layer mapping of all ports, adapters, and domain components implemented in hexaFn's Hexagonal Architecture. Each table is derived from the real data models and flow diagrams in the project documentation.
 
 ---
 
-## 🔵 Core Module (hexafn-core)
+## 🔵 Core Module (`hexafn-core`)
 
 ### Domain Layer
-
 | Component Type | Name | Description | Related Components |
-|----------------|------|-------------|-------------------|
-| Entity | `Pipeline` | Central domain entity representing the 6F Lifecycle Flow | `PipelineStage`, `PipelineContext` |
-| Entity | `Event` | Domain event representation with metadata | `EventMetadata`, `EventPayload` |
-| Value Object | `PipelineStage` | Represents a specific stage in the 6F lifecycle | `Pipeline` |
-| Value Object | `EventMetadata` | Immutable metadata about an event | `Event` |
-| Value Object | `EventId` | Unique identifier for events | `Event` |
-| Domain Service | `PipelineExecutor` | Handles the execution flow of pipeline stages | `Pipeline`, `PipelineStage` |
-| Domain Event | `PipelineStageCompletedEvent` | Signals completion of a pipeline stage | `PipelineStage` |
-| Domain Event | `PipelineCompletedEvent` | Signals the full pipeline has completed | `Pipeline` |
+|---------------|------|-------------|-------------------|
+| Trait | `Pipeline` | 6F lifecycle pipeline abstraction | `PipelineStage`, `PipelineContext` |
+| Trait | `PipelineStage` | Represents a stage in the pipeline (Feed, Filter, etc.) | `PipelineStageType`, `PipelineContext` |
+| Enum | `PipelineStageType` | Stage type: Feed, Filter, Format, Function, Forward, Feedback | - |
+| Struct | `PipelineContext` | Shared context/data for pipeline execution | - |
+| Trait | `Event` | Base event abstraction | `EventId`, `DomainEvent` |
+| Struct | `EventId` | Unique event identifier | `Event` |
+| Trait | `DomainEvent` | Domain event contract | `EventId` |
+| Trait | `HexaError` | Error abstraction for all modules | `HexaErrorKind`, `HexaErrorSeverity` |
+| Enum | `HexaErrorKind` | Error kind (NotFound, Validation, etc.) | `HexaError` |
+| Enum | `HexaErrorSeverity` | Error severity (Low, Medium, High, Critical) | `HexaError` |
+| Trait | `CoreDomainEvent` | Core event for cross-module communication | - |
+| Struct | `PipelineBuilder` | Builder for constructing pipelines | `Pipeline`, `PipelineStage` |
+| Struct | `PipelineStageRegistry` | Registry for pipeline stage factories | `PipelineStageFactory` |
+| Trait | `PipelineStageFactory` | Factory for creating pipeline stages | `PipelineStageType` |
+| Struct | `PipelineStageMetadata` | Metadata for pipeline stages | - |
+| Struct | `PipelineLock` | Locking for pipeline concurrency | - |
+| Struct | `PipelineAuditTrail` | Audit trail for pipeline execution | `PipelineAuditEvent` |
+| Struct | `PipelineTag` | Tag for pipeline categorization | - |
+| Struct | `PipelineDependencyGraph` | Dependency graph for pipelines | - |
+| Struct | `PipelineRollbackPoint` | Rollback point for pipeline state | - |
+| Struct | `PipelineAccessControl` | Access control for pipelines | - |
 
 ### Application Layer
-
 | Component Type | Name | Description | Related Components |
-|----------------|------|-------------|-------------------|
-| Port (Input) | `PipelineControlPort` | Interface for pipeline lifecycle management | `PipelineService` |
-| Port (Input) | `EventProcessingPort` | Interface for event submission and processing | `EventProcessingService` |
-| Port (Output) | `EventStorePort` | Interface for event persistence | `EventRepository` |
-| Port (Output) | `EventPublisherPort` | Interface for event publishing | `EventPublisher` |
-| Service | `PipelineService` | Orchestrates pipeline creation and execution | `Pipeline`, `PipelineExecutor` |
-| Service | `EventProcessingService` | Handles event routing and processing | `Event`, `EventPublisherPort` |
-| Command | `CreatePipelineCommand` | Command to create a new pipeline | `PipelineService` |
-| Command | `ExecutePipelineCommand` | Command to execute a pipeline | `PipelineService` |
-| Query | `GetPipelineStatusQuery` | Query for pipeline execution status | `PipelineService` |
+|---------------|------|-------------|-------------------|
+| Service | `PipelineOrchestrator` | Orchestrates pipeline execution and lifecycle | `PipelineConfig`, `PipelineInstance` |
+| Service | `PipelineConfigLoader` | Loads pipeline configs from files | `PipelineConfig` |
+| Struct | `PipelineConfig` | Pipeline configuration | `PipelineStageConfig` |
+| Struct | `PipelineStageConfig` | Stage configuration | `PipelineStageType` |
+| Struct | `PipelineInstance` | Running pipeline instance | `PipelineStage`, `PipelineStatus` |
+| Enum | `PipelineStatus` | Pipeline status (Running, Stopped, etc.) | - |
+| Command | `PipelineCommand` | Pipeline commands (Start, Stop, Reload) | - |
+| Query | `PipelineQuery` | Pipeline queries (List, Status) | - |
+| Service | `PipelineValidator` | Validates pipeline configs | `PipelineConfig` |
+| Service | `PipelineAuditService` | Records pipeline audit events | `PipelineAuditTrail` |
+| Service | `PipelineLockService` | Manages pipeline locks | - |
+| Service | `PipelineDependencyService` | Resolves pipeline dependencies | - |
+| Service | `PipelineRollbackService` | Manages rollback points | `PipelineRollbackPoint` |
+| Service | `PipelineTaggingService` | Manages pipeline tags | `PipelineTag` |
+| Service | `PipelineAccessControlService` | Manages pipeline access | - |
 
 ### Infrastructure Layer
-
 | Component Type | Name | Description | Related Components |
-|----------------|------|-------------|-------------------|
-| Adapter (Primary) | `PipelineControllerAdapter` | Adapts external requests to pipeline control | `PipelineControlPort` |
-| Adapter (Primary) | `EventReceiverAdapter` | Adapts incoming events to the event processing system | `EventProcessingPort` |
-| Adapter (Secondary) | `InMemoryEventStore` | In-memory implementation of event storage | `EventStorePort` |
-| Adapter (Secondary) | `EventPublisherAdapter` | Implementation of event publishing | `EventPublisherPort` |
-| Mapper | `PipelineDtoMapper` | Maps between Pipeline entities and DTOs | `Pipeline`, `PipelineDto` |
-| Mapper | `EventDtoMapper` | Maps between Event entities and DTOs | `Event`, `EventDto` |
+|---------------|------|-------------|-------------------|
+| Adapter | `PipelineCli` | CLI for pipeline management | `PipelineOrchestrator` |
+| Adapter | `PipelineRepository` | Persists pipeline instances | `PipelineInstance` |
+| Adapter | `PipelineEventBus` | Publishes pipeline events | `CoreDomainEvent` |
+| Mapper | `PipelineMapper` | Maps between pipeline entities and DTOs | `PipelineDto`, `PipelineInstance` |
 | DTO | `PipelineDto` | Data transfer object for pipelines | - |
-| DTO | `EventDto` | Data transfer object for events | - |
+| Adapter | `PipelineAuditRepository` | Persists pipeline audit trails | `PipelineAuditTrail` |
+| Adapter | `PipelineLockManager` | Manages pipeline locks | - |
+| Adapter | `PipelineDependencyAdapter` | Fetches pipeline dependencies | - |
+| Adapter | `PipelineRollbackAdapter` | Manages rollback points | `PipelineRollbackPoint` |
+| Adapter | `PipelineTagStore` | Stores pipeline tags | `PipelineTag` |
+| Adapter | `PipelineAccessControlAdapter` | Manages pipeline access | - |
 
 ---
 
-## 🔄 Trigger Module (hexafn-trigger)
+## 🟢 Trigger Module (`hexafn-trigger`)
 
 ### Domain Layer
-
 | Component Type | Name | Description | Related Components |
-|----------------|------|-------------|-------------------|
-| Entity | `Trigger` | Core entity representing a triggerable condition | `TriggerCondition`, `TriggerAction` |
-| Entity | `TriggerExecution` | Records the execution of a trigger | `Trigger`, `ExecutionResult` |
-| Value Object | `TriggerCondition` | Encapsulates the logic for when a trigger fires | `Trigger` |
-| Value Object | `TriggerName` | Identifies a trigger uniquely | `Trigger` |
-| Value Object | `TriggerPriority` | Defines the priority of trigger evaluation | `Trigger` |
-| Domain Service | `TriggerEvaluator` | Core business logic for evaluating trigger conditions | `Trigger`, `TriggerCondition` |
-| Domain Event | `TriggerCreatedEvent` | Signals a new trigger was created | `Trigger` |
-| Domain Event | `TriggerFiredEvent` | Signals a trigger condition was met | `Trigger`, `TriggerExecution` |
+|---------------|------|-------------|-------------------|
+| Trait | `Trigger` | Trigger abstraction (id, name, evaluate, etc.) | `TriggerCondition` |
+| Trait | `TriggerCondition` | Condition for trigger evaluation | `CompoundType` |
+| Enum | `CompoundType` | Compound condition type (And, Or, Not) | - |
+| Trait | `TriggerEvent` | Base event for triggers | - |
+| Struct | `TriggerCreatedEvent` | Event for trigger creation | - |
+| Struct | `TriggerFiredEvent` | Event for trigger firing | - |
+| Struct | `TriggerDeactivatedEvent` | Event for trigger deactivation | - |
+| Struct | `TriggerAuditTrail` | Audit trail for triggers | `TriggerAuditEvent` |
+| Struct | `TriggerLock` | Locking for triggers | - |
+| Struct | `TriggerDependencyGraph` | Dependency graph for triggers | - |
+| Struct | `TriggerRollbackPoint` | Rollback point for triggers | - |
+| Struct | `TriggerTag` | Tag for triggers | - |
+| Struct | `TriggerAccessControl` | Access control for triggers | - |
 
 ### Application Layer
-
 | Component Type | Name | Description | Related Components |
-|----------------|------|-------------|-------------------|
-| Port (Input) | `TriggerManagementPort` | Interface for trigger CRUD operations | `TriggerManagementService` |
-| Port (Input) | `TriggerEvaluationPort` | Interface for evaluating triggers against events | `TriggerEvaluationService` |
-| Port (Output) | `TriggerRepositoryPort` | Interface for trigger persistence | `TriggerRepository` |
-| Port (Output) | `TriggerEventPublisherPort` | Interface for publishing trigger events | `TriggerEventPublisher` |
-| Service | `TriggerManagementService` | Handles trigger creation, update, deletion | `Trigger`, `TriggerRepositoryPort` |
-| Service | `TriggerEvaluationService` | Orchestrates trigger evaluation against incoming events | `TriggerEvaluator`, `TriggerRepositoryPort` |
-| Command | `CreateTriggerCommand` | Command to create a new trigger | `TriggerManagementService` |
-| Command | `UpdateTriggerCommand` | Command to update an existing trigger | `TriggerManagementService` |
-| Query | `GetTriggersQuery` | Query to retrieve triggers | `TriggerManagementService` |
+|---------------|------|-------------|-------------------|
+| Port | `TriggerRegistryPort` | Register, unregister, list triggers | `Trigger` |
+| Port | `TriggerEvaluationPort` | Evaluate triggers | `Trigger` |
+| Service | `TriggerService` | Activate, deactivate, reload triggers | `TriggerRegistryPort`, `TriggerEvaluationPort` |
+| Command | `TriggerCommand` | Trigger commands (Activate, Deactivate, etc.) | - |
+| Query | `TriggerQuery` | Trigger queries (List, Get) | - |
+| Service | `TriggerValidator` | Validates trigger configs | `TriggerConfig` |
+| Service | `TriggerConfigLoader` | Loads trigger configs from files | `TriggerConfig` |
+| Struct | `TriggerConfig` | Trigger configuration | `TriggerConditionConfig` |
+| Struct | `TriggerConditionConfig` | Condition configuration | `CompoundType` |
+| Service | `TriggerAuditService` | Records trigger audit events | `TriggerAuditTrail` |
+| Service | `TriggerLockService` | Manages trigger locks | - |
+| Service | `TriggerDependencyService` | Resolves trigger dependencies | - |
+| Service | `TriggerRollbackService` | Manages rollback points | `TriggerRollbackPoint` |
+| Service | `TriggerTaggingService` | Manages trigger tags | `TriggerTag` |
+| Service | `TriggerAccessControlService` | Manages trigger access | - |
 
 ### Infrastructure Layer
-
 | Component Type | Name | Description | Related Components |
-|----------------|------|-------------|-------------------|
-| Adapter (Primary) | `TriggerApiAdapter` | Adapts HTTP/API requests to trigger management | `TriggerManagementPort` |
-| Adapter (Primary) | `TriggerEventConsumerAdapter` | Consumes events for trigger evaluation | `TriggerEvaluationPort` |
-| Adapter (Secondary) | `TriggerDatabaseRepository` | Persists triggers to database | `TriggerRepositoryPort` |
-| Adapter (Secondary) | `TriggerEventPublisherImpl` | Publishes trigger events to event bus | `TriggerEventPublisherPort` |
-| Mapper | `TriggerDtoMapper` | Maps between Trigger entities and DTOs | `Trigger`, `TriggerDto` |
-| Mapper | `TriggerConditionMapper` | Maps between different condition formats | `TriggerCondition`, `TriggerConditionDto` |
+|---------------|------|-------------|-------------------|
+| Adapter | `TriggerRepository` | Persists triggers | `Trigger` |
+| Adapter | `TriggerEventBus` | Publishes trigger events | `TriggerEvent` |
+| Adapter | `TriggerCli` | CLI for trigger management | `Trigger` |
+| Mapper | `TriggerMapper` | Maps between trigger entities and DTOs | `TriggerDto`, `Trigger` |
 | DTO | `TriggerDto` | Data transfer object for triggers | - |
-| DTO | `TriggerConditionDto` | Data transfer object for trigger conditions | - |
+| Adapter | `TriggerAuditRepository` | Persists trigger audit trails | `TriggerAuditTrail` |
+| Adapter | `TriggerLockManager` | Manages trigger locks | - |
+| Adapter | `TriggerDependencyAdapter` | Fetches trigger dependencies | - |
+| Adapter | `TriggerRollbackAdapter` | Manages rollback points | `TriggerRollbackPoint` |
+| Adapter | `TriggerTagStore` | Stores trigger tags | `TriggerTag` |
+| Adapter | `TriggerAccessControlAdapter` | Manages trigger access | - |
 
 ---
 
-## ⚡ Run Module (hexafn-run)
+## 🟠 Run Module (`hexafn-run`)
 
 ### Domain Layer
-
 | Component Type | Name | Description | Related Components |
-|----------------|------|-------------|-------------------|
-| Entity | `Function` | Core entity representing executable logic | `FunctionCode`, `FunctionConfig` |
-| Entity | `FunctionExecution` | Records function execution with inputs/outputs | `Function`, `ExecutionResult` |
-| Value Object | `FunctionCode` | Contains the executable code of a function | `Function` |
-| Value Object | `FunctionConfig` | Configuration parameters for function execution | `Function` |
-| Value Object | `ExecutionResult` | Output and status of a function execution | `FunctionExecution` |
-| Domain Service | `FunctionExecutor` | Core business logic for function execution | `Function`, `Runtime` |
-| Domain Event | `FunctionRegisteredEvent` | Signals a new function was registered | `Function` |
-| Domain Event | `FunctionExecutedEvent` | Signals a function was executed | `FunctionExecution` |
+|---------------|------|-------------|-------------------|
+| Trait | `FunctionRuntime` | Function runtime abstraction (execute, init, shutdown) | `FunctionContext`, `ExecutionResult` |
+| Struct | `FunctionContext` | Context for function execution | - |
+| Struct | `ExecutionResult` | Result of function execution | - |
+| Enum | `ExecutionStatus` | Status of execution (Success, Failure, etc.) | - |
+| Struct | `Error` | Error details for execution | - |
+| Struct | `FunctionRegisteredEvent` | Event for function registration | - |
+| Struct | `FunctionExecutedEvent` | Event for function execution | - |
+| Struct | `FunctionAuditTrail` | Audit trail for functions | `FunctionExecutedEvent` |
+| Struct | `FunctionLock` | Locking for functions | - |
+| Struct | `FunctionDependencyGraph` | Dependency graph for functions | - |
+| Struct | `FunctionRollbackPoint` | Rollback point for functions | - |
+| Struct | `FunctionTag` | Tag for functions | - |
+| Struct | `FunctionAccessControl` | Access control for functions | - |
 
 ### Application Layer
-
 | Component Type | Name | Description | Related Components |
-|----------------|------|-------------|-------------------|
-| Port (Input) | `FunctionRegistryPort` | Interface for registering functions | `FunctionRegistryService` |
-| Port (Input) | `FunctionExecutionPort` | Interface for executing functions | `FunctionExecutionService` |
-| Port (Output) | `FunctionRepositoryPort` | Interface for function persistence | `FunctionRepository` |
-| Port (Output) | `RuntimeProviderPort` | Interface for runtime management | `RuntimeProvider` |
-| Service | `FunctionRegistryService` | Manages function registration and discovery | `Function`, `FunctionRepositoryPort` |
-| Service | `FunctionExecutionService` | Orchestrates function execution | `FunctionExecutor`, `RuntimeProviderPort` |
-| Command | `RegisterFunctionCommand` | Command to register a new function | `FunctionRegistryService` |
-| Command | `ExecuteFunctionCommand` | Command to execute a function | `FunctionExecutionService` |
-| Query | `GetFunctionQuery` | Query to retrieve a function | `FunctionRegistryService` |
+|---------------|------|-------------|-------------------|
+| Port | `FunctionRegistryPort` | Register, remove, list functions | `FunctionDefinition` |
+| Port | `FunctionExecutionPort` | Execute functions | `FunctionContext`, `ExecutionResult` |
+| Service | `RunService` | Selects runtime, validates input/output, fallback chain | `FunctionRuntime` |
+| Service | `FunctionConfigLoader` | Loads function configs from files | `FunctionConfig` |
+| Struct | `FunctionConfig` | Function configuration | - |
+| Struct | `FunctionDefinition` | Function definition | - |
+| Command | `RunCommand` | Run commands (Register, Remove, Test) | - |
+| Query | `RunQuery` | Run queries (List, Get) | - |
+| Service | `RunValidator` | Validates function configs and results | `FunctionConfig`, `ExecutionResult` |
+| Service | `FunctionAuditService` | Records function audit events | `FunctionAuditTrail` |
+| Service | `FunctionLockService` | Manages function locks | - |
+| Service | `FunctionDependencyService` | Resolves function dependencies | - |
+| Service | `FunctionRollbackService` | Manages rollback points | `FunctionRollbackPoint` |
+| Service | `FunctionTaggingService` | Manages function tags | `FunctionTag` |
+| Service | `FunctionAccessControlService` | Manages function access | - |
 
 ### Infrastructure Layer
-
 | Component Type | Name | Description | Related Components |
-|----------------|------|-------------|-------------------|
-| Adapter (Primary) | `FunctionApiAdapter` | Adapts HTTP/API requests to function operations | `FunctionRegistryPort`, `FunctionExecutionPort` |
-| Adapter (Primary) | `FunctionEventConsumerAdapter` | Consumes events for function execution | `FunctionExecutionPort` |
-| Adapter (Secondary) | `FunctionDatabaseRepository` | Persists functions to database | `FunctionRepositoryPort` |
-| Adapter (Secondary) | `WasmRuntimeAdapter` | WebAssembly runtime implementation | `RuntimeProviderPort` |
-| Adapter (Secondary) | `JsRuntimeAdapter` | JavaScript runtime implementation | `RuntimeProviderPort` |
-| Adapter (Secondary) | `LuaRuntimeAdapter` | Lua runtime implementation | `RuntimeProviderPort` |
-| Adapter (Secondary) | `DslRuntimeAdapter` | Internal DSL runtime implementation | `RuntimeProviderPort` |
-| Mapper | `FunctionDtoMapper` | Maps between Function entities and DTOs | `Function`, `FunctionDto` |
+|---------------|------|-------------|-------------------|
+| Adapter | `FunctionRepository` | Persists function definitions | `FunctionDefinition` |
+| Adapter | `RuntimeFactory` | Provides runtime implementations | `FunctionRuntime` |
+| Adapter | `RunEventBus` | Publishes function execution events | `FunctionExecutedEvent` |
+| Adapter | `RunCli` | CLI for function management/testing | `FunctionDefinition` |
+| Mapper | `RunMapper` | Maps between function entities and DTOs | `FunctionDto`, `FunctionDefinition` |
 | DTO | `FunctionDto` | Data transfer object for functions | - |
-| DTO | `ExecutionRequestDto` | DTO for function execution requests | - |
+| Adapter | `FunctionAuditRepository` | Persists function audit trails | `FunctionAuditTrail` |
+| Adapter | `FunctionLockManager` | Manages function locks | - |
+| Adapter | `FunctionDependencyAdapter` | Fetches function dependencies | - |
+| Adapter | `FunctionRollbackAdapter` | Manages rollback points | `FunctionRollbackPoint` |
+| Adapter | `FunctionTagStore` | Stores function tags | `FunctionTag` |
+| Adapter | `FunctionAccessControlAdapter` | Manages function access | - |
 
 ---
 
-## 📦 Store Module (hexafn-store)
+## 🟡 Store Module (`hexafn-store`)
 
 ### Domain Layer
-
 | Component Type | Name | Description | Related Components |
-|----------------|------|-------------|-------------------|
-| Entity | `KeyValueEntry` | Core entity representing a stored KV pair | `Key`, `Value`, `Metadata` |
-| Entity | `Namespace` | Logical grouping of related KV entries | `KeyValueEntry` |
-| Value Object | `Key` | Identifier for a stored value | `KeyValueEntry` |
-| Value Object | `Value` | Content of a stored entry | `KeyValueEntry` |
-| Value Object | `Metadata` | Additional data about a KV entry | `KeyValueEntry` |
-| Domain Service | `EntryValidator` | Validates entries against schemas | `KeyValueEntry`, `Schema` |
-| Domain Event | `EntryCreatedEvent` | Signals a new KV entry was created | `KeyValueEntry` |
-| Domain Event | `EntryUpdatedEvent` | Signals a KV entry was updated | `KeyValueEntry` |
+|---------------|------|-------------|-------------------|
+| Trait | `KvStore` | Key-value store abstraction (CRUD, transaction) | `Namespace`, `KeyValueEntry`, `KvOp` |
+| Struct | `Namespace` | Namespace for key scoping | - |
+| Struct | `KeyValueEntry` | Key-value entry with metadata | - |
+| Enum | `KvOp` | KV operation (Put, Delete) | - |
+| Struct | `StoreEntryCreatedEvent` | Event for entry creation | - |
+| Struct | `StoreEntryUpdatedEvent` | Event for entry update | - |
+| Struct | `StoreEntryDeletedEvent` | Event for entry deletion | - |
+| Struct | `StoreAuditTrail` | Audit trail for store | `StoreAuditEvent` |
+| Struct | `StoreLock` | Locking for store | - |
+| Struct | `StoreDependencyGraph` | Dependency graph for store | - |
+| Struct | `StoreRollbackPoint` | Rollback point for store | - |
+| Struct | `StoreTag` | Tag for store | - |
+| Struct | `StoreAccessControl` | Access control for store | - |
+| Struct | `StoreSnapshot` | Store snapshot for backup | - |
+| Struct | `StoreReplication` | Store replication status | - |
+| Struct | `StoreChangeFeed` | Change feed for store | - |
+| Struct | `StoreAccessAudit` | Access audit for store | - |
+| Struct | `StoreQuotaManager` | Quota management for store | - |
+| Struct | `StoreSchemaMigration` | Schema migration for store | - |
+| Struct | `StoreSoftDelete` | Soft delete for entries | - |
+| Struct | `StoreKeyRotation` | Key rotation for entries | - |
 
 ### Application Layer
-
 | Component Type | Name | Description | Related Components |
-|----------------|------|-------------|-------------------|
-| Port (Input) | `KvStorePort` | Interface for KV CRUD operations | `KvStoreService` |
-| Port (Input) | `NamespaceManagementPort` | Interface for namespace operations | `NamespaceService` |
-| Port (Output) | `KvStoragePort` | Interface for KV backend storage | `KvStorageAdapter` |
-| Port (Output) | `SchemaValidatorPort` | Interface for schema validation | `SchemaValidator` |
-| Service | `KvStoreService` | Manages KV operations and validation | `EntryValidator`, `KvStoragePort` |
-| Service | `NamespaceService` | Manages namespaces | `Namespace`, `KvStoragePort` |
-| Command | `StoreEntryCommand` | Command to store a KV entry | `KvStoreService` |
-| Command | `DeleteEntryCommand` | Command to delete a KV entry | `KvStoreService` |
-| Query | `GetEntryQuery` | Query to retrieve a KV entry | `KvStoreService` |
+|---------------|------|-------------|-------------------|
+| Port | `KvStorePort` | CRUD and transaction operations | `KeyValueEntry`, `KvOp` |
+| Service | `StoreService` | Backup, restore, TTL, validation | `KvStorePort` |
+| Command | `StoreCommand` | Store commands (Backup, SetTTL, etc.) | - |
+| Query | `StoreQuery` | Store queries (ListNamespaces, GetEntry) | - |
+| Service | `StoreValidator` | Validates entry schemas | `KeyValueEntry` |
+| Service | `StoreConfigLoader` | Loads store configs from files | `StoreConfig` |
+| Struct | `StoreConfig` | Store configuration | `NamespaceConfig` |
+| Struct | `NamespaceConfig` | Namespace configuration | - |
+| Service | `StoreAuditService` | Records store audit events | `StoreAuditTrail` |
+| Service | `StoreLockService` | Manages store locks | - |
+| Service | `StoreDependencyService` | Resolves store dependencies | - |
+| Service | `StoreRollbackService` | Manages rollback points | `StoreRollbackPoint` |
+| Service | `StoreTaggingService` | Manages store tags | `StoreTag` |
+| Service | `StoreAccessControlService` | Manages store access | - |
 
 ### Infrastructure Layer
-
 | Component Type | Name | Description | Related Components |
-|----------------|------|-------------|-------------------|
-| Adapter (Primary) | `KvApiAdapter` | Adapts HTTP/API requests to KV operations | `KvStorePort` |
-| Adapter (Primary) | `KvCliAdapter` | CLI interface for KV operations | `KvStorePort` |
-| Adapter (Secondary) | `InMemoryKvAdapter` | In-memory implementation of KV storage | `KvStoragePort` |
-| Adapter (Secondary) | `FileKvAdapter` | File-based implementation of KV storage | `KvStoragePort` |
-| Adapter (Secondary) | `RocksDbKvAdapter` | RocksDB implementation of KV storage | `KvStoragePort` |
-| Adapter (Secondary) | `JsonSchemaValidator` | JSON Schema validation implementation | `SchemaValidatorPort` |
-| Mapper | `KvEntryDtoMapper` | Maps between KV entities and DTOs | `KeyValueEntry`, `KvEntryDto` |
-| DTO | `KvEntryDto` | Data transfer object for KV entries | - |
-| DTO | `NamespaceDto` | Data transfer object for namespaces | - |
+|---------------|------|-------------|-------------------|
+| Adapter | `StoreRepository` | Persists key-value entries | `KeyValueEntry` |
+| Adapter | `StoreEventBus` | Publishes store events | `StoreEntryCreatedEvent` |
+| Adapter | `StoreCli` | CLI for store management | `KeyValueEntry` |
+| Mapper | `StoreMapper` | Maps between store entities and DTOs | `StoreDto`, `KeyValueEntry` |
+| DTO | `StoreDto` | Data transfer object for store entries | - |
+| Adapter | `StoreAuditRepository` | Persists store audit trails | `StoreAuditTrail` |
+| Adapter | `StoreLockManager` | Manages store locks | - |
+| Adapter | `StoreDependencyAdapter` | Fetches store dependencies | - |
+| Adapter | `StoreRollbackAdapter` | Manages rollback points | `StoreRollbackPoint` |
+| Adapter | `StoreTagStore` | Stores store tags | `StoreTag` |
+| Adapter | `StoreAccessControlAdapter` | Manages store access | - |
 
 ---
 
-## 📡 Cast Module (hexafn-cast)
+## 🟣 Cast Module (`hexafn-cast`)
 
 ### Domain Layer
-
 | Component Type | Name | Description | Related Components |
-|----------------|------|-------------|-------------------|
-| Entity | `Topic` | Core entity representing a message topic | `Subscription`, `Message` |
-| Entity | `Subscription` | Represents a subscriber to a topic | `Topic`, `SubscriptionFilter` |
-| Value Object | `Message` | Content and metadata of a topic message | `Topic` |
-| Value Object | `SubscriptionFilter` | Filter criteria for topic messages | `Subscription` |
-| Value Object | `TopicName` | Identifier for a topic | `Topic` |
-| Domain Service | `MessageRouter` | Routes messages to subscriptions | `Topic`, `Subscription` |
-| Domain Event | `TopicCreatedEvent` | Signals a new topic was created | `Topic` |
-| Domain Event | `MessagePublishedEvent` | Signals a message was published | `Topic`, `Message` |
+|---------------|------|-------------|-------------------|
+| Struct | `Topic` | Pub/sub topic | - |
+| Struct | `RetentionPolicy` | Retention policy for topics | - |
+| Trait | `Publisher` | Publishes messages to topics | `Topic` |
+| Trait | `Subscriber` | Subscribes to topics | `Topic` |
+| Enum | `SubscriberLifecycle` | Subscriber lifecycle state | - |
+| Struct | `Message` | Pub/sub message | `DeliveryStatus` |
+| Enum | `DeliveryStatus` | Message delivery status | - |
+| Struct | `MessageDeliveredEvent` | Event for message delivery | - |
+| Struct | `TopicCreatedEvent` | Event for topic creation | - |
+| Struct | `TopicRetentionPolicyChangedEvent` | Event for retention policy change | - |
+| Struct | `CastAuditTrail` | Audit trail for cast | `CastAuditEvent` |
+| Struct | `CastLock` | Locking for cast | - |
+| Struct | `CastDependencyGraph` | Dependency graph for cast | - |
+| Struct | `CastRollbackPoint` | Rollback point for cast | - |
+| Struct | `CastTag` | Tag for cast | - |
+| Struct | `CastAccessControl` | Access control for cast | - |
+| Struct | `TopicPartitioning` | Topic partitioning info | - |
+| Struct | `TopicACL` | Topic access control list | - |
+| Struct | `TopicVersioning` | Topic version info | - |
+| Struct | `TopicCompaction` | Topic compaction policy | - |
+| Struct | `TopicReplayWindow` | Topic replay window | - |
+| Struct | `SubscriberGroup` | Group of subscribers | - |
+| Struct | `SubscriberOffsetManagement` | Offset management for subscribers | - |
+| Struct | `SubscriberDeadLetterQueue` | Dead letter queue for subscribers | - |
+| Struct | `MessageEncryption` | Message encryption metadata | - |
+| Struct | `MessageCompression` | Message compression info | - |
+| Struct | `MessageOrderingGuarantee` | Message ordering policy | - |
+| Struct | `MessageDeduplication` | Message deduplication info | - |
+| Struct | `MessageAuditTrail` | Audit trail for messages | `DeliveryStatus` |
 
 ### Application Layer
-
 | Component Type | Name | Description | Related Components |
-|----------------|------|-------------|-------------------|
-| Port (Input) | `TopicManagementPort` | Interface for topic CRUD operations | `TopicService` |
-| Port (Input) | `PublisherPort` | Interface for publishing messages | `PublisherService` |
-| Port (Input) | `SubscriptionPort` | Interface for subscription management | `SubscriptionService` |
-| Port (Output) | `MessageBusPort` | Interface for message delivery | `MessageBus` |
-| Port (Output) | `TopicRepositoryPort` | Interface for topic persistence | `TopicRepository` |
-| Service | `TopicService` | Manages topics and retention policies | `Topic`, `TopicRepositoryPort` |
-| Service | `PublisherService` | Handles message publishing | `MessageRouter`, `MessageBusPort` |
-| Service | `SubscriptionService` | Manages subscriptions | `Subscription`, `TopicRepositoryPort` |
-| Command | `CreateTopicCommand` | Command to create a new topic | `TopicService` |
-| Command | `PublishMessageCommand` | Command to publish a message | `PublisherService` |
-| Query | `GetSubscriptionsQuery` | Query to retrieve subscriptions | `SubscriptionService` |
+|---------------|------|-------------|-------------------|
+| Port | `TopicManagementPort` | Manage topics | `Topic` |
+| Port | `PublisherPort` | Publish messages | `Topic` |
+| Port | `SubscriberPort` | Manage subscribers | `Subscriber` |
+| Service | `CastService` | Registers subscribers, publishes messages | `TopicManagementPort`, `PublisherPort`, `SubscriberPort` |
+| Service | `TopicConfigLoader` | Loads topic configs from files | `TopicConfig` |
+| Struct | `TopicConfig` | Topic configuration | - |
+| Struct | `TopicFilter` | Filter for topic messages | - |
+| Command | `CastCommand` | Cast commands (CreateTopic, etc.) | - |
+| Query | `CastQuery` | Cast queries (ListTopics, etc.) | - |
+| Service | `CastValidator` | Validates topic configs | `TopicConfig` |
+| Service | `CastAuditService` | Records cast audit events | `CastAuditTrail` |
+| Service | `CastLockService` | Manages cast locks | - |
+| Service | `CastDependencyService` | Resolves cast dependencies | - |
+| Service | `CastRollbackService` | Manages rollback points | `CastRollbackPoint` |
+| Service | `CastTaggingService` | Manages cast tags | `CastTag` |
+| Service | `CastAccessControlService` | Manages cast access | - |
 
 ### Infrastructure Layer
-
 | Component Type | Name | Description | Related Components |
-|----------------|------|-------------|-------------------|
-| Adapter (Primary) | `CastApiAdapter` | Adapts HTTP/API requests to Cast operations | `TopicManagementPort`, `PublisherPort` |
-| Adapter (Primary) | `CastCliAdapter` | CLI interface for Cast operations | `TopicManagementPort`, `SubscriptionPort` |
-| Adapter (Secondary) | `InMemoryMessageBus` | In-memory implementation of message bus | `MessageBusPort` |
-| Adapter (Secondary) | `TopicDatabaseRepository` | Persists topics and subscriptions | `TopicRepositoryPort` |
-| Mapper | `TopicDtoMapper` | Maps between Topic entities and DTOs | `Topic`, `TopicDto` |
-| Mapper | `MessageDtoMapper` | Maps between Message value objects and DTOs | `Message`, `MessageDto` |
-| DTO | `TopicDto` | Data transfer object for topics | - |
-| DTO | `MessageDto` | Data transfer object for messages | - |
-| DTO | `SubscriptionDto` | Data transfer object for subscriptions | - |
+|---------------|------|-------------|-------------------|
+| Adapter | `CastRepository` | Persists topics and subscribers | `Topic`, `Subscriber` |
+| Adapter | `CastEventBus` | Publishes message delivery events | `MessageDeliveredEvent` |
+| Adapter | `CastCli` | CLI for cast management | `Topic`, `Subscriber` |
+| Mapper | `CastMapper` | Maps between cast entities and DTOs | `CastDto`, `Message` |
+| DTO | `CastDto` | Data transfer object for cast messages | - |
+| Adapter | `OutputForwarder` | Forwards outputs to targets | `OutputTarget` |
+| Enum | `OutputTarget` | Output target type (Http, Cast, etc.) | - |
+| Adapter | `CastAuditRepository` | Persists cast audit trails | `CastAuditTrail` |
+| Adapter | `CastLockManager` | Manages cast locks | - |
+| Adapter | `CastDependencyAdapter` | Fetches cast dependencies | - |
+| Adapter | `CastRollbackAdapter` | Manages rollback points | `CastRollbackPoint` |
+| Adapter | `CastTagStore` | Stores cast tags | `CastTag` |
+| Adapter | `CastAccessControlAdapter` | Manages cast access | - |
 
 ---
 
-## 🔍 Watch Module (hexafn-watch)
+## 🟤 Bridge Module (`hexafn-bridge`)
 
 ### Domain Layer
-
 | Component Type | Name | Description | Related Components |
-|----------------|------|-------------|-------------------|
-| Entity | `Trace` | Core entity representing a distributed trace | `Span`, `TraceContext` |
-| Entity | `Span` | Individual operation within a trace | `Trace`, `SpanContext` |
-| Value Object | `TraceContext` | Propagation context for a trace | `Trace` |
-| Value Object | `SpanContext` | Context of an operation span | `Span` |
-| Value Object | `LogEntry` | Structured log record | `Span` |
-| Domain Service | `TracePropagator` | Manages trace context across boundaries | `Trace`, `TraceContext` |
-| Domain Event | `SpanStartedEvent` | Signals a span was started | `Span` |
-| Domain Event | `SpanFinishedEvent` | Signals a span was completed | `Span` |
+|---------------|------|-------------|-------------------|
+| Trait | `Integration` | External integration abstraction | `EventTransformer` |
+| Trait | `Webhook` | Webhook endpoint abstraction | `HttpMethod`, `Response` |
+| Trait | `EventTransformer` | Transforms and validates events | - |
+| Trait | `BridgeEvent` | Base event for bridge | - |
+| Struct | `WebhookReceivedEvent` | Event for webhook received | - |
+| Struct | `IntegrationRegisteredEvent` | Event for integration registration | - |
+| Enum | `ConnectionStatus` | Integration connection status | - |
+| Enum | `HttpMethod` | HTTP method for webhooks | - |
+| Struct | `Response` | HTTP response for webhooks | - |
+| Struct | `BridgeAuditTrail` | Audit trail for bridge | `BridgeAuditEvent` |
+| Struct | `BridgeLock` | Locking for bridge | - |
+| Struct | `BridgeDependencyGraph` | Dependency graph for bridge | - |
+| Struct | `BridgeRollbackPoint` | Rollback point for bridge | - |
+| Struct | `BridgeTag` | Tag for bridge | - |
+| Struct | `BridgeAccessControl` | Access control for bridge | - |
+| Struct | `IntegrationHealthCheck` | Health check for integrations | - |
+| Struct | `IntegrationRetryPolicy` | Retry policy for integrations | - |
+| Struct | `IntegrationCircuitBreaker` | Circuit breaker for integrations | - |
+| Struct | `IntegrationRateLimit` | Rate limiting for integrations | - |
+| Struct | `IntegrationTransformationTemplate` | Transformation template for integrations | - |
+| Struct | `IntegrationApprovalWorkflow` | Approval workflow for integrations | - |
+| Struct | `IntegrationSecretManager` | Secret management for integrations | - |
+| Struct | `IntegrationAuditTrail` | Audit trail for integrations | - |
 
 ### Application Layer
-
 | Component Type | Name | Description | Related Components |
-|----------------|------|-------------|-------------------|
-| Port (Input) | `TracingPort` | Interface for tracing operations | `TracingService` |
-| Port (Input) | `LoggingPort` | Interface for structured logging | `LoggingService` |
-| Port (Input) | `MetricsPort` | Interface for metrics collection | `MetricsService` |
-| Port (Output) | `TraceExporterPort` | Interface for exporting traces | `TraceExporter` |
-| Port (Output) | `LogExporterPort` | Interface for exporting logs | `LogExporter` |
-| Port (Output) | `MetricsExporterPort` | Interface for exporting metrics | `MetricsExporter` |
-| Service | `TracingService` | Manages trace lifecycle and spans | `Trace`, `TracePropagator` |
-| Service | `LoggingService` | Manages structured logging | `LogEntry`, `LogExporterPort` |
-| Service | `MetricsService` | Collects and exposes metrics | `MetricsExporterPort` |
-| Command | `StartSpanCommand` | Command to start a new span | `TracingService` |
-| Command | `LogEventCommand` | Command to log an event | `LoggingService` |
-| Query | `GetTraceQuery` | Query to retrieve a trace | `TracingService` |
+|---------------|------|-------------|-------------------|
+| Port | `IntegrationManagementPort` | Register, remove, list integrations | `Integration` |
+| Port | `WebhookReceiverPort` | Receive webhooks | `Webhook` |
+| Service | `BridgeService` | Normalizes payloads, dispatches events | `IntegrationManagementPort`, `WebhookReceiverPort` |
+| Service | `IntegrationConfigLoader` | Loads integration configs from files | `IntegrationConfig` |
+| Struct | `IntegrationConfig` | Integration configuration | - |
+| Command | `BridgeCommand` | Bridge commands (RegisterIntegration, etc.) | - |
+| Query | `BridgeQuery` | Bridge queries (ListIntegrations, etc.) | - |
+| Service | `BridgeAuditService` | Records bridge audit events | `BridgeAuditTrail` |
+| Service | `BridgeLockService` | Manages bridge locks | - |
+| Service | `BridgeDependencyService` | Resolves bridge dependencies | - |
+| Service | `BridgeRollbackService` | Manages rollback points | `BridgeRollbackPoint` |
+| Service | `BridgeTaggingService` | Manages bridge tags | `BridgeTag` |
+| Service | `BridgeAccessControlService` | Manages bridge access | - |
 
 ### Infrastructure Layer
-
 | Component Type | Name | Description | Related Components |
-|----------------|------|-------------|-------------------|
-| Adapter (Primary) | `TracingApiAdapter` | Adapts HTTP/API requests to tracing operations | `TracingPort` |
-| Adapter (Primary) | `LoggingMacroAdapter` | Adapts logging macros to structured logging | `LoggingPort` |
-| Adapter (Secondary) | `OpenTelemetryTraceExporter` | Exports traces to OpenTelemetry | `TraceExporterPort` |
-| Adapter (Secondary) | `JsonLogExporter` | Exports logs as JSON lines | `LogExporterPort` |
-| Adapter (Secondary) | `PrometheusMetricsExporter` | Exports metrics to Prometheus | `MetricsExporterPort` |
-| Mapper | `TraceDtoMapper` | Maps between Trace entities and DTOs | `Trace`, `TraceDto` |
-| Mapper | `LogEntryDtoMapper` | Maps between LogEntry value objects and DTOs | `LogEntry`, `LogEntryDto` |
-| DTO | `TraceDto` | Data transfer object for traces | - |
-| DTO | `SpanDto` | Data transfer object for spans | - |
-| DTO | `LogEntryDto` | Data transfer object for log entries | - |
-
----
-
-## 🌐 Bridge Module (hexafn-bridge)
-
-### Domain Layer
-
-| Component Type | Name | Description | Related Components |
-|----------------|------|-------------|-------------------|
-| Entity | `Integration` | Core entity representing an external integration | `IntegrationType`, `IntegrationConfig` |
-| Entity | `Webhook` | Represents a webhook endpoint integration | `Integration`, `WebhookConfig` |
-| Value Object | `IntegrationType` | Type of external integration | `Integration` |
-| Value Object | `IntegrationConfig` | Configuration for an integration | `Integration` |
-| Value Object | `WebhookConfig` | Configuration specific to webhooks | `Webhook` |
-| Domain Service | `PayloadNormalizer` | Normalizes external data formats | `Integration`, `Event` |
-| Domain Event | `IntegrationRegisteredEvent` | Signals a new integration was registered | `Integration` |
-| Domain Event | `WebhookReceivedEvent` | Signals data was received via webhook | `Webhook` |
-
-### Application Layer
-
-| Component Type | Name | Description | Related Components |
-|----------------|------|-------------|-------------------|
-| Port (Input) | `IntegrationManagementPort` | Interface for integration CRUD operations | `IntegrationService` |
-| Port (Input) | `WebhookReceiverPort` | Interface for receiving webhook data | `WebhookService` |
-| Port (Output) | `IntegrationRepositoryPort` | Interface for integration persistence | `IntegrationRepository` |
-| Port (Output) | `EventDispatcherPort` | Interface for dispatching normalized events | `EventDispatcher` |
-| Service | `IntegrationService` | Manages external integrations | `Integration`, `IntegrationRepositoryPort` |
-| Service | `WebhookService` | Handles webhook data reception | `Webhook`, `PayloadNormalizer` |
-| Command | `RegisterIntegrationCommand` | Command to register a new integration | `IntegrationService` |
-| Command | `ProcessWebhookCommand` | Command to process webhook data | `WebhookService` |
-| Query | `GetIntegrationsQuery` | Query to retrieve integrations | `IntegrationService` |
-
-### Infrastructure Layer
-
-| Component Type | Name | Description | Related Components |
-|----------------|------|-------------|-------------------|
-| Adapter (Primary) | `IntegrationApiAdapter` | Adapts HTTP/API requests to integration management | `IntegrationManagementPort` |
-| Adapter (Primary) | `WebhookHttpAdapter` | HTTP endpoint for receiving webhooks | `WebhookReceiverPort` |
-| Adapter (Secondary) | `IntegrationDatabaseRepository` | Persists integrations to database | `IntegrationRepositoryPort` |
-| Adapter (Secondary) | `EventDispatcherAdapter` | Dispatches normalized events to Cast | `EventDispatcherPort` |
-| Mapper | `IntegrationDtoMapper` | Maps between Integration entities and DTOs | `Integration`, `IntegrationDto` |
-| Mapper | `WebhookPayloadMapper` | Maps webhook payloads to normalized format | `WebhookConfig`, `Event` |
+|---------------|------|-------------|-------------------|
+| Adapter | `IntegrationRepository` | Persists integrations | `Integration` |
+| Adapter | `BridgeEventBus` | Publishes bridge events | `BridgeEvent` |
+| Adapter | `BridgeCli` | CLI for bridge management | `Integration` |
+| Mapper | `BridgeMapper` | Maps between integration entities and DTOs | `IntegrationDto`, `Integration` |
 | DTO | `IntegrationDto` | Data transfer object for integrations | - |
-| DTO | `WebhookDto` | Data transfer object for webhooks | - |
-| DTO | `WebhookPayloadDto` | Data transfer object for webhook payloads | - |
+| Adapter | `BridgeAuditRepository` | Persists bridge audit trails | `BridgeAuditTrail` |
+| Adapter | `BridgeLockManager` | Manages bridge locks | - |
+| Adapter | `BridgeDependencyAdapter` | Fetches bridge dependencies | - |
+| Adapter | `BridgeRollbackAdapter` | Manages rollback points | `BridgeRollbackPoint` |
+| Adapter | `BridgeTagStore` | Stores bridge tags | `BridgeTag` |
+| Adapter | `BridgeAccessControlAdapter` | Manages bridge access | - |
+
+---
+
+## 🟠 Watch Module (`hexafn-watch`)
+
+### Domain Layer
+| Component Type | Name | Description | Related Components |
+|---------------|------|-------------|-------------------|
+| Trait | `Trace` | Distributed trace abstraction | `Span` |
+| Struct | `Span` | Trace span | - |
+| Struct | `LogEntry` | Structured log entry | `LogLevel` |
+| Enum | `LogLevel` | Log level (Trace, Debug, etc.) | - |
+| Struct | `MetricPoint` | Metric data point | - |
+| Trait | `WatchEvent` | Base event for watch | - |
+| Struct | `AlertTriggeredEvent` | Event for alert triggered | - |
+| Struct | `WatchAuditTrail` | Audit trail for watch | `WatchAuditEvent` |
+| Struct | `WatchLock` | Locking for watch | - |
+| Struct | `WatchDependencyGraph` | Dependency graph for watch | - |
+| Struct | `WatchRollbackPoint` | Rollback point for watch | - |
+| Struct | `WatchTag` | Tag for watch | - |
+| Struct | `WatchAccessControl` | Access control for watch | - |
+| Struct | `LogRedaction` | Log redaction logic | - |
+| Struct | `LogRetentionPolicy` | Log retention policy | - |
+| Struct | `LogExporters` | Log exporters | - |
+| Struct | `TraceCorrelation` | Trace correlation logic | - |
+| Struct | `TraceSamplingPolicy` | Trace sampling policy | - |
+| Struct | `AlertSuppression` | Alert suppression logic | - |
+| Struct | `AlertEscalation` | Alert escalation logic | - |
+| Struct | `MetricsDownsampling` | Metrics downsampling logic | - |
+| Struct | `MetricsCustomAggregator` | Custom metrics aggregation | - |
+| Struct | `WatchAccessAudit` | Access audit for watch | - |
+
+### Application Layer
+| Component Type | Name | Description | Related Components |
+|---------------|------|-------------|-------------------|
+| Port | `LoggingPort` | Structured logging | `LogEntry` |
+| Port | `TracingPort` | Tracing operations | `Trace` |
+| Port | `MetricsPort` | Metrics collection | `MetricPoint` |
+| Service | `WatchService` | Tails logs, exports metrics, triggers alerts | `LoggingPort`, `TracingPort`, `MetricsPort` |
+| Struct | `LogFilter` | Log filtering | - |
+| Struct | `AlertConfig` | Alert configuration | - |
+| Command | `WatchCommand` | Watch commands (TailLogs, etc.) | - |
+| Query | `WatchQuery` | Watch queries (GetTrace, etc.) | - |
+| Service | `WatchAuditService` | Records watch audit events | `WatchAuditTrail` |
+| Service | `WatchLockService` | Manages watch locks | - |
+| Service | `WatchDependencyService` | Resolves watch dependencies | - |
+| Service | `WatchRollbackService` | Manages rollback points | `WatchRollbackPoint` |
+| Service | `WatchTaggingService` | Manages watch tags | `WatchTag` |
+| Service | `WatchAccessControlService` | Manages watch access | - |
+
+### Infrastructure Layer
+| Component Type | Name | Description | Related Components |
+|---------------|------|-------------|-------------------|
+| Adapter | `LogExporter` | Exports logs | `LogEntry` |
+| Adapter | `TraceExporter` | Exports traces | `Trace` |
+| Adapter | `MetricsExporter` | Exports metrics | `MetricPoint` |
+| Adapter | `WatchCli` | CLI for watch management | `LogEntry`, `MetricPoint` |
+| Mapper | `WatchMapper` | Maps between watch entities and DTOs | `WatchDto`, `LogEntry` |
+| DTO | `WatchDto` | Data transfer object for watch logs | - |
+| Adapter | `WatchAuditRepository` | Persists watch audit trails | `WatchAuditTrail` |
+| Adapter | `WatchLockManager` | Manages watch locks | - |
+| Adapter | `WatchDependencyAdapter` | Fetches watch dependencies | - |
+| Adapter | `WatchRollbackAdapter` | Manages rollback points | `WatchRollbackPoint` |
+| Adapter | `WatchTagStore` | Stores watch tags | `WatchTag` |
+| Adapter | `WatchAccessControlAdapter` | Manages watch access | - |
 
 ---
 
 ## 📚 References
 
-- Hexagonal Architecture (Ports & Adapters): [HEXAGONAL_ARCHITECTURE_GUIDE.md](HEXAGONAL_ARCHITECTURE_GUIDE.md)
-- Module Structure: [PROJECT_STRUCTURE.md](PROJECT_STRUCTURE.md)
-- 6F Lifecycle Flow: [ARCHITECTURE.md](ARCHITECTURE.md)
+- Hexagonal Architecture (Ports & Adapters): [HEXAGONAL_ARCHITECTURE_GUIDE](HEXAGONAL_ARCHITECTURE_GUIDE.md)
+- Module Structure: [PROJECT_STRUCTURE](PROJECT_STRUCTURE.md)
+- 6F Lifecycle Flow: [ARCHITECTURE](ARCHITECTURE.md)
+- Data Models: [DATA_MODEL_CORE](DATA_MODEL_CORE.md), [DATA_MODEL_TRIGGER](DATA_MODEL_TRIGGER.md), [DATA_MODEL_RUN](DATA_MODEL_RUN.md), [DATA_MODEL_STORE](DATA_MODEL_STORE.md), [DATA_MODEL_CAST](DATA_MODEL_CAST.md), [DATA_MODEL_BRIDGE](DATA_MODEL_BRIDGE.md), [DATA_MODEL_WATCH](DATA_MODEL_WATCH.md)
+- Data Flow: [DATA_FLOW](DATA_FLOW.md), [DATA_FLOW_DETAIL](DATA_FLOW_DETAIL.md)
+- TODO List: [TODO_LIST](TODO_LIST.md)
 
 ---
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -11,56 +11,71 @@ Welcome to the hexaFn project documentation hub. This file summarizes the struct
 
 ## 🧭 Project Strategy & Structure
 
-- [`SUMMARY.md`](SUMMARY.md) – High-level summary of all documentation files
-- [`ARCHITECTURE.md`](ARCHITECTURE.md) – System design and internal architecture
-- [`USE_CASES.md`](USE_CASES.md) – Core problems the project addresses and examples
+- [SUMMARY](SUMMARY.md) – High-level summary of all documentation files
+- [ARCHITECTURE](ARCHITECTURE.md) – System design and internal architecture
+- [USE_CASES](USE_CASES.md) – Core problems the project addresses and examples
 
 ---
 
 ## 🛠 Contribution & Workflow
 
-- [`CONTRIBUTING.md`](CONTRIBUTING.md) – Guidelines for contributing (issues, PRs, code)
-- [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) – Community behavior rules
-- [`PR_STRATEGY.md`](PR_STRATEGY.md) – Rules for naming, reviewing, and merging PRs
-- [`COMMIT_STRATEGY.md`](COMMIT_STRATEGY.md) – Commit message types and best practices
-- [`BRANCH_STRATEGY.md`](BRANCH_STRATEGY.md) – Naming and usage rules for git branches
-- [`LABELLING_STRATEGY.md`](LABELLING_STRATEGY.md) – System of issue/PR labels and their purpose
-- [`PROJECT_STRUCTURE.md`](PROJECT_STRUCTURE.md) – Directory structure and module breakdown
+- [CONTRIBUTING](CONTRIBUTING.md) – Guidelines for contributing (issues, PRs, code)
+- [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md) – Community behavior rules
+- [PR_STRATEGY](PR_STRATEGY.md) – Rules for naming, reviewing, and merging PRs
+- [COMMIT_STRATEGY](COMMIT_STRATEGY.md) – Commit message types and best practices
+- [BRANCH_STRATEGY](BRANCH_STRATEGY.md) – Naming and usage rules for git branches
+- [LABELLING_STRATEGY](LABELLING_STRATEGY.md) – System of issue/PR labels and their purpose
+- [PROJECT_STRUCTURE](PROJECT_STRUCTURE.md) – Directory structure and module breakdown
 
 ---
 
 ## 📈 Planning & Management
 
-- [`MILESTONES.md`](MILESTONES.md) – Key milestones and development phases
-- [`PROJECT_BOARD.md`](PROJECT_BOARD.md) – GitHub Projects board usage guide
-- [`ROADMAP.md`](ROADMAP.md) – Development roadmap and release strategy
+- [MILESTONES](MILESTONES.md) – Key milestones and development phases
+- [PROJECT_BOARD](PROJECT_BOARD.md) – GitHub Projects board usage guide
+- [ROADMAP](ROADMAP.md) – Development roadmap and release strategy
 
 ---
 
 ## 👨‍💻 Developer Tools
 
-- [`CONFIGURATION.md`](CONFIGURATION.md) – Runtime and environment settings
-- [`STYLE_GUIDE.md`](STYLE_GUIDE.md) – Coding conventions and formatting rules
-- [`GETTING_STARTED.md`](GETTING_STARTED.md) – Setup instructions for new devs
-- [`HEXAGONAL_ARCHITECTURE_GUIDE.md`](HEXAGONAL_ARCHITECTURE_GUIDE.md) - Protocol-agnostic implementation patterns and data flow
-- [`DEVELOPMENT_GUIDE.md`](DEVELOPMENT_GUIDE.md) – In-depth dev guide
-- [`FAQ.md`](FAQ.md) – Frequently asked questions
+- [CONFIGURATION](CONFIGURATION.md) – Runtime and environment settings
+- [STYLE_GUIDE](STYLE_GUIDE.md) – Coding conventions and formatting rules
+- [GETTING_STARTED](GETTING_STARTED.md) – Setup instructions for new devs
+- [HEXAGONAL_ARCHITECTURE_GUIDE](HEXAGONAL_ARCHITECTURE_GUIDE.md) - Protocol-agnostic implementation patterns and data flow
+- [DEVELOPMENT_GUIDE](DEVELOPMENT_GUIDE.md) – In-depth dev guide
+- [FAQ](FAQ.md) – Frequently asked questions
+
+---
+
+## 🗂️ Architecture & Data Model References
+
+- [DATA_MODEL_CORE](DATA_MODEL_CORE.md) – Core data model definitions
+- [DATA_MODEL_TRIGGER](DATA_MODEL_TRIGGER.md) – Trigger module data model
+- [DATA_MODEL_RUN](DATA_MODEL_RUN.md) – Run module data model
+- [DATA_MODEL_STORE](DATA_MODEL_STORE.md) – Store module data model
+- [DATA_MODEL_CAST](DATA_MODEL_CAST.md) – Cast module data model
+- [DATA_MODEL_BRIDGE](DATA_MODEL_BRIDGE.md) – Bridge module data model
+- [DATA_MODEL_WATCH](DATA_MODEL_WATCH.md) – Watch module data model
+- [DATA_FLOW](DATA_FLOW.md) – High-level data flow across modules
+- [DATA_FLOW_DETAIL](DATA_FLOW_DETAIL.md) – Detailed component and interface data flow
+- [RUST_PORTS_ADAPTERS_EXAMPLE](RUST_PORTS_ADAPTERS_EXAMPLE.md) – Complete mapping of ports, adapters, and domain components
 
 ---
 
 ## 🤝 Community & Support
 
-- [`COMMUNITY.md`](COMMUNITY.md) – Community engagement and interaction rules
-- [`CONTACT.md`](CONTACT.md) – How to reach maintainers or report issues
-- [`SUPPORT.md`](SUPPORT.md) – How to get help and where to ask questions
+- [COMMUNITY](COMMUNITY.md) – Community engagement and interaction rules
+- [CONTACT](CONTACT.md) – How to reach maintainers or report issues
+- [SUPPORT](SUPPORT.md) – How to get help and where to ask questions
 
 ---
 
 ## 🌐 Branding & Website
 
-- [`BRANDING.md`](BRANDING.md) – Visual identity and logo usage
-- [`CNAME`](CNAME) – Custom domain for GitHub Pages
-- [`Web Site`](https://hexafn.com) – Landing page of documentation site
+- [BRANDING](BRANDING.md) – Visual identity and logo usage
+- [CNAME](CNAME) – Custom domain for GitHub Pages
+- [Web Site](https://hexafn.com) – Landing page of documentation site
 
 ---
 

--- a/docs/TODO_LIST.md
+++ b/docs/TODO_LIST.md
@@ -20,7 +20,7 @@ This document tracks the development progress of the hexaFn project organized by
 
 | ID | Title | Status | Description |
 |----|-------|--------|-------------|
-| 447 | Initialize project structure and base modules | OPEN | Set up the initial Rust project with Cargo and create the base directory structure for core and modules (core pipeline, trigger engine, run engine, etc.) according to the planned architecture. |
+| 447 | Initialize project structure and base modules | CLOSED | Set up the initial Rust project with Cargo and create the base directory structure for core and modules (core pipeline, trigger engine, run engine, etc.) according to the planned architecture. |
 | 448 | Design the internal DSL for function logic | OPEN | Define the syntax and capabilities of the internal domain-specific language (DSL) used for writing function logic in HexaRun. |
 | 449 | Implement basic DSL parser and executor | OPEN | Develop a minimal parser and interpreter for the internal DSL to execute function logic. |
 | 450 | Define HexaTrigger trait and event model | OPEN | Design and implement the core 'Trigger' trait along with an event/context model that triggers will evaluate. |


### PR DESCRIPTION

Closes #447

## 📄 Summary

This PR sets up the initial Rust project structure for hexaFn, including:
- Cargo workspace configuration and root dependencies
- All core and module crates under /crates (core, trigger, run, store, cast, watch, bridge)
- Hexagonal Architecture directory layout for each module (domain, application, infrastructure)
- SPDX headers in all new files for REUSE compliance
- Initial mod.rs and placeholder contract files in domain/contracts/
- README.md for each module describing purpose and architecture
- Structure validated against docs/PROJECT_STRUCTURE.md and docs/HEXAGONAL_ARCHITECTURE_GUIDE.md
- Build and test verified for the workspace

## 🧩 Affected Module(s)

- [x] HexaStore
- [x] HexaCast
- [x] HexaRun
- [x] HexaTrigger
- [x] HexaWatch
- [x] HexaBridge
- [x] Core Logic
- [x] Documentation
- [x] CI / Infra

## ✅ Checklist

- [x] My branch name follows format: feat/project-structure-init-447
- [x] My PR title starts with an approved type
- [x] All code passes formatting and lint checks
- [x] All tests pass
- [x] Related issue is linked (Closes #447)
- [x] No unrelated changes included
- [x] SPDX headers present in all new files

---

This PR establishes the foundation for further development according to the planned architecture and 6F Lifecycle Flow.
